### PR TITLE
kokkos linking cleanup

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ env:
   BUILD_TYPE: RelWithDebInfo
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     container:
       image:  ghcr.io/fnalacceleratormodeling/synergia2-ubuntu-container:main
@@ -33,24 +33,7 @@ jobs:
         . /etc/profile.d/z10_spack_environment.sh 
         . /opt/view/setvars.sh
         cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-    - name: Upload the build output
-      uses: actions/upload-artifact@v2
-      with:
-        name: build-output
-        path: |
-          ${{github.workspace}}/build
 
-  test:
-    needs: [build]
-    runs-on: ubuntu-latest
-    container:
-      image:  ghcr.io/fnalacceleratormodeling/synergia2-ubuntu-container:main
-  
-    steps:
-    - name: Download the build output
-      uses: actions/download-artifact@v2
-      with:
-        name: build-output
     - name: ctest
     # Execute tests defined by the CMake configuration.
       run:  |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(extra_includes)
 option(SIMPLE_TIMER "use the simple timer 2 profiling" Off)
 option(BUILD_PYTHON_BINDINGS "build the Python bindings of Synergia" On)
 option(ALLOW_PADDING "add paddings to the particle array for memory alignment" On)
+option(USE_EXTERNAL_KOKKOS "Use external build of kokkos" Off)
 option(Kokkos_ENABLE_OPENMP "enable openmp backend" On)
 option(Kokkos_ENABLE_CUDA "enable CUDA backend" Off)
 
@@ -255,8 +256,16 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 # include paths
 smart_include_directories("${extra_includes}")
 
-# kokkos
-add_subdirectory(src/synergia/utils/kokkos)
+# Follow official kokkos guidelines
+# https://github.com/kokkos/kokkos/wiki/Compiling#42-using-general-cmake-build-system
+if (USE_EXTERNAL_KOKKOS)
+  find_package(Kokkos REQUIRED)
+  set(kokkos_libs "Kokkos::kokkos")
+else ()
+  add_subdirectory(src/synergia/utils/kokkos)
+  include_directories(${Kokkos_INCLUDE_DIRS_RET})
+  set(kokkos_libs kokkos)
+endif()
 
 if(${Kokkos_ENABLE_CUDA})
     add_definitions(-DKokkos_ENABLE_CUDA)

--- a/src/synergia/bunch/CMakeLists.txt
+++ b/src/synergia/bunch/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(synergia_bunch
     synergia_hdf5_utils 
     synergia_foundation 
     synergia_serialization 
-    kokkos
+    ${kokkos_libs}
     )
 
 target_link_options(synergia_bunch

--- a/src/synergia/bunch/tests/CMakeLists.txt
+++ b/src/synergia/bunch/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(test_bunch_traits test_bunch_traits.cc)
-target_link_libraries(test_bunch_traits kokkos)
+target_link_libraries(test_bunch_traits ${kokkos_libs})
 add_mpi_test(test_bunch_traits 1)
 
 add_executable(test_bunch test_bunch.cc)

--- a/src/synergia/foundation/CMakeLists.txt
+++ b/src/synergia/foundation/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(synergia_foundation
     lsexpr
     gsl
     gslcblas
-    Kokkos::kokkos
+    ${kokkos_libs}
     )
 
 target_link_options(synergia_foundation

--- a/src/synergia/lattice/tests/CMakeLists.txt
+++ b/src/synergia/lattice/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(test_mx_expr test_mx_expr.cc)
 target_link_libraries(test_mx_expr
     synergia_lattice
     synergia_test_main
-    kokkos)
+    ${kokkos_libs})
 add_mpi_test(test_mx_expr 1)
 
 
@@ -24,7 +24,7 @@ add_executable(test_madx_parser test_madx_parser.cc)
 target_link_libraries(test_madx_parser
     synergia_lattice
     synergia_test_main
-    kokkos)
+    ${kokkos_libs})
 add_mpi_test(test_madx_parser 1)
 
 copy_file(foo.dbx test_madx_parser)

--- a/src/synergia/libFF/tests/CMakeLists.txt
+++ b/src/synergia/libFF/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(test_libff_elements test_libff_elements.cc)
 target_link_libraries(test_libff_elements 
     synergia_simulation 
     synergia_test_main
-    kokkos)
+    ${kokkos_libs})
 add_mpi_test(test_libff_elements 1)
 copy_file(fodo.madx test_libff_elements)
 
@@ -11,21 +11,21 @@ add_executable(test_madx_multipoles test_madx_multipoles.cc)
 target_link_libraries(test_madx_multipoles
     synergia_simulation 
     synergia_test_main
-    kokkos)
+    ${kokkos_libs})
 add_mpi_test(test_madx_multipoles 1)
 
 add_executable(test_madx_elements test_madx_elements.cc)
 target_link_libraries(test_madx_elements
     synergia_simulation 
     synergia_test_main
-    kokkos)
+    ${kokkos_libs})
 add_mpi_test(test_madx_elements 1)
 
 add_executable(test_foils test_foils.cc)
 target_link_libraries(test_foils
     synergia_simulation 
     synergia_test_main
-    kokkos)
+    ${kokkos_libs})
 add_mpi_test(test_foils 1)
 
 

--- a/src/synergia/utils/CMakeLists.txt
+++ b/src/synergia/utils/CMakeLists.txt
@@ -9,14 +9,14 @@ set(synergia_parallel_utils_src
 add_library(synergia_parallel_utils        SHARED ${synergia_parallel_utils_src})
 add_library(synergia_parallel_utils_static STATIC ${synergia_parallel_utils_src})
 
-target_link_libraries(synergia_parallel_utils MPI::MPI_C Kokkos::kokkos)
-target_link_libraries(synergia_parallel_utils_static MPI::MPI_C Kokkos::kokkos)
+target_link_libraries(synergia_parallel_utils MPI::MPI_C ${kokkos_libs})
+target_link_libraries(synergia_parallel_utils_static MPI::MPI_C ${kokkos_libs})
 
 target_link_options(synergia_parallel_utils PRIVATE ${LINKER_OPTIONS})
 target_link_options(synergia_parallel_utils_static PRIVATE ${LINKER_OPTIONS})
 
 add_library(synergia_test_main STATIC catch_test_main.cc)
-target_link_libraries(synergia_test_main kokkos MPI::MPI_C)
+target_link_libraries(synergia_test_main ${kokkos_libs} MPI::MPI_C)
 
 add_library(synergia_serialization cereal_files.cc)
 target_link_libraries(synergia_serialization synergia_parallel_utils)
@@ -29,7 +29,7 @@ add_library(synergia_hdf5_utils
 target_link_libraries(synergia_hdf5_utils 
     ${HDF5_LIBRARIES} 
     synergia_parallel_utils
-    Kokkos::kokkos
+    ${kokkos_libs}
     )
 target_link_options(synergia_hdf5_utils 
     PRIVATE ${LINKER_OPTIONS}
@@ -49,7 +49,7 @@ if (BUILD_PYTHON_BINDINGS)
     target_link_libraries(pylsexpr PRIVATE lsexpr)
 
     pybind11_add_module(utils MODULE NO_EXTRAS utils_pywrap.cc)
-    target_link_libraries(utils PRIVATE kokkoscore)
+    target_link_libraries(utils PRIVATE ${kokkos_libs})
 
     copy_file(__init__.py utils)
 
@@ -82,7 +82,7 @@ add_library(synergia_distributed_fft
 target_link_libraries(synergia_distributed_fft 
     ${FFT_LIB}
     synergia_parallel_utils
-    Kokkos::kokkos
+    ${kokkos_libs}
     )
 
 target_link_options(synergia_distributed_fft 
@@ -90,14 +90,14 @@ target_link_options(synergia_distributed_fft
     )
 
 add_library(synergia_command_line command_line_arg.cc)
-target_link_libraries(synergia_command_line Kokkos::kokkos)
+target_link_libraries(synergia_command_line ${kokkos_libs})
 target_link_options(synergia_command_line PRIVATE ${LINKER_OPTIONS})
 
 add_library(lsexpr SHARED lsexpr.cc)
 add_library(lsexpr_static STATIC lsexpr.cc)
 
-target_link_libraries(lsexpr Kokkos::kokkos)
-target_link_libraries(lsexpr_static Kokkos::kokkos)
+target_link_libraries(lsexpr ${kokkos_libs})
+target_link_libraries(lsexpr_static ${kokkos_libs})
 target_link_options(lsexpr PRIVATE ${LINKER_OPTIONS})
 target_link_options(lsexpr_static PRIVATE ${LINKER_OPTIONS})
 


### PR DESCRIPTION
Consistently use either `Kokkos::kokkos` or `kokkos`, but do not mix the two as is currently done. 