### PR TITLE
ensure portability of mpiexec arguments for both mpich and openmpi

### DIFF
--- a/CMake/MPITest.cmake
+++ b/CMake/MPITest.cmake
@@ -6,7 +6,7 @@ macro(add_mpi_test tname np)
                 OMP_NUM_THREADS=1
                 OMP_PROC_BIND=spread
                 OMP_PLACES=cores
-                ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} --bind-to-core
+                ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np}
                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${tname}> ${MPIEXEC_POSTFLAGS})
     else()
         add_test(NAME ${tname}_${np}

--- a/src/synergia/utils/tests/test_distributed_fft2d.cc
+++ b/src/synergia/utils/tests/test_distributed_fft2d.cc
@@ -6,7 +6,7 @@
 #include <cmath>
 
 // set DBGPRINT to 1 to print values for tolerance failures
-#define DBGPRINT 0
+#define DBGPRINT 1
 
 #if DBGPRINT
 #include <iostream>


### PR DESCRIPTION
`--bind-to-core` is a deprecated argument to OpenMPI (support has been already dropped for upcoming versions) and silently fails on OS X. Moreover, OS X does not even support process binding per this [thread](https://www.mail-archive.com/users@lists.open-mpi.org//msg34849.html).

On Linux, while `--bind-to core` is portable between OpenMPI and MPICH, in practice it is leading to segfaults on the tiny CI instance with only 2 cores when using `libc++`. 

Thus, it might be best to avoid using the `--bind-to core` option altogether and let anyone who has a reasonably powerful machine (thereby not requiring over-subscription) add it in their local instance when doing development work. 