### PR TITLE
minor kokkos cleanup

### DIFF
--- a/src/synergia/bunch/populate.cc
+++ b/src/synergia/bunch/populate.cc
@@ -1,168 +1,154 @@
 #include <sstream>
 #include <stdexcept>
 
+#include "core_diagnostics.h"
 #include "populate.h"
 #include "populate_host.h"
-#include "core_diagnostics.h"
 
-#include "synergia/utils/floating_point.h"
 #include "synergia/foundation/math_constants.h"
+#include "synergia/utils/floating_point.h"
 
 using mconstants::pi;
 
-namespace 
-{
-    bool is_symmetric66(const_karray2d_row m) 
-    {
-        bool symmetric = true;
-        const double tolerance = 1.0e-14;
+namespace {
+  bool
+  is_symmetric66(const_karray2d_row m)
+  {
+    bool symmetric = true;
+    const double tolerance = 1.0e-14;
 
-        for (int i = 0; i < 6; ++i) 
-        {
-            for (int j = i + 1; j < 6; ++j) 
-            { 
-                if (!floating_point_equal(m(i, j), m(j, i), tolerance)) 
-                { 
-                    symmetric = false; 
-                } 
-            } 
-        } 
-
-        return symmetric;
+    for (int i = 0; i < 6; ++i) {
+      for (int j = i + 1; j < 6; ++j) {
+        if (!floating_point_equal(m(i, j), m(j, i), tolerance)) {
+          symmetric = false;
+        }
+      }
     }
+
+    return symmetric;
+  }
 }
 
 void
-adjust_moments( Bunch & bunch, 
-        const_karray1d means,
-        const_karray2d_row covariances )
+adjust_moments(Bunch& bunch,
+               const_karray1d means,
+               const_karray2d_row covariances)
 {
-    if (!is_symmetric66(covariances))
-        throw std::runtime_error("adjust_moments: covariance matrix must be symmetric");
+  if (!is_symmetric66(covariances))
+    throw std::runtime_error(
+      "adjust_moments: covariance matrix must be symmetric");
 
-    // calculate_mean and mom2 are performed on device memory, so we need to
-    // copy the particle data from host to device first. checkout is not
-    // necessary since the core diagnostics do not change the particle data
-    bunch.checkin_particles();
+  // calculate_mean and mom2 are performed on device memory, so we need to
+  // copy the particle data from host to device first. checkout is not
+  // necessary since the core diagnostics do not change the particle data
+  bunch.checkin_particles();
 
-    karray1d bunch_mean = Core_diagnostics::calculate_mean(bunch);
-    karray2d_row bunch_mom2 = Core_diagnostics::calculate_mom2(bunch, bunch_mean);
+  karray1d bunch_mean = Core_diagnostics::calculate_mean(bunch);
+  karray2d_row bunch_mom2 = Core_diagnostics::calculate_mom2(bunch, bunch_mean);
 
-    int num_particles = bunch.size();
-    int num_particles_slots = bunch.capacity();
+  int num_particles = bunch.size();
+  int num_particles_slots = bunch.capacity();
 
-    //auto strides = bunch.get_particle_strides();
-    //int num_particles_slots = strides[1];
+  // auto strides = bunch.get_particle_strides();
+  // int num_particles_slots = strides[1];
 
-    adjust_moments_host(
-            means.data(),
-            covariances.data(),
-            bunch_mean.data(),
-            bunch_mom2.data(),
-            num_particles,
-            num_particles_slots,
-            bunch.get_host_particles().data() );
+  adjust_moments_host(means.data(),
+                      covariances.data(),
+                      bunch_mean.data(),
+                      bunch_mom2.data(),
+                      num_particles,
+                      num_particles_slots,
+                      bunch.get_host_particles().data());
 }
 
-namespace
-{
-    void
-    fill_unit_6d( Distribution & dist, 
-                  HostParticles particles,
-                  const_karray2d_row covariances, 
-                  int start, int end )
-    {
-        for (int j = 0; j < 6; ++j) 
-        {
-            const double scale = sqrt( covariances(j, j) );
+namespace {
+  void
+  fill_unit_6d(Distribution& dist,
+               HostParticles particles,
+               const_karray2d_row covariances,
+               int start,
+               int end)
+  {
+    for (int j = 0; j < 6; ++j) {
+      const double scale = sqrt(covariances(j, j));
 
-            for(int p=start; p<end; ++p)
-                particles(p, j) = dist.get_unit_gaussian() * scale;
-        }
+      for (int p = start; p < end; ++p)
+        particles(p, j) = dist.get_unit_gaussian() * scale;
+    }
+  }
+
+  inline bool
+  good(ConstHostParticles particles, const_karray1d limits, int index)
+  {
+    bool retval = true;
+
+    for (int i = 0; i < 6; ++i) {
+      double val = particles(index, i);
+      double limit = limits[i];
+
+      if ((limit > 0) && ((val > limit) or (val < -limit))) retval = false;
     }
 
-    inline bool
-    good( ConstHostParticles particles, 
-          const_karray1d limits, 
-          int index )
-    {
-        bool retval = true;
+    return retval;
+  }
 
-        for (int i = 0; i < 6; ++i) 
-        {
-            double val = particles(index, i);
-            double limit = limits[i];
+  void
+  strip_unit_6d(Bunch& bunch,
+                const_karray1d limits,
+                int& total_num,
+                int& local_num)
+  {
+    auto particles = bunch.get_host_particles();
+    local_num = bunch.get_local_num();
 
-            if ((limit > 0) && ((val > limit) or (val < -limit))) 
-                retval = false;
+    int index = 0;
+    while (index < local_num) {
+      if (good(particles, limits, index)) {
+        ++index;
+      } else {
+        int last = local_num - 1;
+        if (good(particles, limits, last)) {
+          particles(index, 0) = particles(last, 0);
+          particles(index, 1) = particles(last, 1);
+          particles(index, 2) = particles(last, 2);
+          particles(index, 3) = particles(last, 3);
+          particles(index, 4) = particles(last, 4);
+          particles(index, 5) = particles(last, 5);
         }
 
-        return retval;
+        --local_num;
+      }
     }
 
-    void
-    strip_unit_6d( Bunch & bunch, 
-                   const_karray1d limits, 
-                   int & total_num,
-                   int & local_num )
-    {
-        auto particles = bunch.get_host_particles();
-        local_num = bunch.get_local_num();
-
-        int index = 0;
-        while (index < local_num) 
-        {
-            if (good(particles, limits, index)) 
-            {
-                ++index;
-            } 
-            else 
-            {
-                int last = local_num - 1;
-                if (good(particles, limits, last)) 
-                {
-                    particles(index, 0) = particles(last, 0);
-                    particles(index, 1) = particles(last, 1);
-                    particles(index, 2) = particles(last, 2);
-                    particles(index, 3) = particles(last, 3);
-                    particles(index, 4) = particles(last, 4);
-                    particles(index, 5) = particles(last, 5);
-                }
-
-                --local_num;
-            }
-        }
-
-        MPI_Allreduce(&local_num, &total_num, 1, MPI_INT, MPI_SUM,
-                bunch.get_comm());
-    }
+    MPI_Allreduce(
+      &local_num, &total_num, 1, MPI_INT, MPI_SUM, bunch.get_comm());
+  }
 }
 
 void
-populate_6d( Distribution & dist, 
-        Bunch & bunch, 
-        const_karray1d means,
-        const_karray2d_row covariances )
+populate_6d(Distribution& dist,
+            Bunch& bunch,
+            const_karray1d means,
+            const_karray2d_row covariances)
 {
-    if (bunch.size() != bunch.get_local_num())
-    {
-        throw std::runtime_error(
-                "populate_6d: "
-                "cannot populate bunches that has already lost particles." );
-    }
+  if (bunch.size() != bunch.get_local_num()) {
+    throw std::runtime_error(
+      "populate_6d: "
+      "cannot populate bunches that has already lost particles.");
+  }
 
-    karray1d limits("limits", 6);
-    for(int i=0; i<6; ++i) limits[i] = 0.0;
+  karray1d limits("limits", 6);
+  for (int i = 0; i < 6; ++i) limits[i] = 0.0;
 
-    populate_6d_truncated(dist, bunch, means, covariances, limits);
+  populate_6d_truncated(dist, bunch, means, covariances, limits);
 }
 
 void
-populate_6d_truncated( Distribution & dist, 
-        Bunch & bunch,
-        const_karray1d means, 
-        const_karray2d_row covariances,
-        const_karray1d limits )
+populate_6d_truncated(Distribution& dist,
+                      Bunch& bunch,
+                      const_karray1d means,
+                      const_karray2d_row covariances,
+                      const_karray1d limits)
 {
 #if 0
     multi_array_assert_size(means, 6, "populate_6d: means");
@@ -170,149 +156,142 @@ populate_6d_truncated( Distribution & dist,
     multi_array_assert_size(limits, 6, "populate_6d: limits");
 #endif
 
-    // deep copy from device to host
-    bunch.checkout_particles();
+  // deep copy from device to host
+  bunch.checkout_particles();
 
-    auto particles = bunch.get_host_particles();
+  auto particles = bunch.get_host_particles();
 
-    karray2d_row unit_covariances("unit_covariances", 6, 6);
-    karray1d zero_means("zero_means", 6);
+  karray2d_row unit_covariances("unit_covariances", 6, 6);
+  karray1d zero_means("zero_means", 6);
 
-    bool truncated(false);
+  bool truncated(false);
 
-    for (int i = 0; i < 6; ++i) 
-    {
-        double n = limits[i];
+  for (int i = 0; i < 6; ++i) {
+    double n = limits[i];
 
-        if (n > 0) 
-        {
-            truncated = true;
+    if (n > 0) {
+      truncated = true;
 
-            double cutoff_integral = 
-                ( exp(-n*n/2.0) ) * 
-                ( sqrt(pi) * exp(n*n/2.0) * erf(n/sqrt(2.0)) - sqrt(2.0)*n ) / 
-                ( sqrt(pi) );
+      double cutoff_integral =
+        (exp(-n * n / 2.0)) *
+        (sqrt(pi) * exp(n * n / 2.0) * erf(n / sqrt(2.0)) - sqrt(2.0) * n) /
+        (sqrt(pi));
 
-            unit_covariances(i, i) = 1.0 / (cutoff_integral * cutoff_integral);
-        } 
-        else 
-        {
-            unit_covariances(i, i) = 1.0;
-        }
+      unit_covariances(i, i) = 1.0 / (cutoff_integral * cutoff_integral);
+    } else {
+      unit_covariances(i, i) = 1.0;
     }
+  }
 
-    int start = 0;
-    int end = bunch.get_local_num();
+  int start = 0;
+  int end = bunch.get_local_num();
 
-    fill_unit_6d(dist, particles, unit_covariances, start, end);
+  fill_unit_6d(dist, particles, unit_covariances, start, end);
 
-    if (truncated) 
-    {
-        adjust_moments(bunch, zero_means, unit_covariances);
+  if (truncated) {
+    adjust_moments(bunch, zero_means, unit_covariances);
 
-        int iteration = 0;
-        int total_num, local_num;
+    int iteration = 0;
+    int total_num, local_num;
 
-        strip_unit_6d(bunch, limits, total_num, local_num);
+    strip_unit_6d(bunch, limits, total_num, local_num);
 
-        while (total_num < bunch.get_total_num()) 
-        {
-            ++iteration;
-            const int max_iterations = 50;
-            if (iteration > max_iterations) {
-                throw std::runtime_error(
-                        "populate_6d_truncated: "
-                        "maximum number of truncation iterations exceeded. "
-                        "Algorithm known to fail ~< 2.5 sigma." );
-            }
+    while (total_num < bunch.get_total_num()) {
+      ++iteration;
+      const int max_iterations = 50;
+      if (iteration > max_iterations) {
+        throw std::runtime_error(
+          "populate_6d_truncated: "
+          "maximum number of truncation iterations exceeded. "
+          "Algorithm known to fail ~< 2.5 sigma.");
+      }
 
-            fill_unit_6d(dist, particles, unit_covariances, local_num, end);
-            adjust_moments(bunch, zero_means, unit_covariances);
-            strip_unit_6d(bunch, limits, total_num, local_num);
-        }
+      fill_unit_6d(dist, particles, unit_covariances, local_num, end);
+      adjust_moments(bunch, zero_means, unit_covariances);
+      strip_unit_6d(bunch, limits, total_num, local_num);
     }
+  }
 
-    adjust_moments(bunch, means, covariances);
+  adjust_moments(bunch, means, covariances);
 
-    // copy to device
-    bunch.checkin_particles();
+  // copy to device
+  bunch.checkin_particles();
 
-    // check
-    bunch.check_pz2_positive();
+  // check
+  bunch.check_pz2_positive();
 }
 
 karray2d_row
-get_correlation_matrix(
-        const_karray2d_row one_turn_map,
-        double arms, double brms, double crms, double beta, 
-        std::array<int, 3> const& rms_index)
-{  
+get_correlation_matrix(const_karray2d_row one_turn_map,
+                       double arms,
+                       double brms,
+                       double crms,
+                       double beta,
+                       std::array<int, 3> const& rms_index)
+{
 
-    for(int idx : rms_index)
-    {
-        if (idx<0 || idx>5)
-            throw std::runtime_error(
-                    "only valid rms indices (x=0, xp=1, y=2, "
-                    "yp=3, z=4, dpp=5) are allowed");
-    } 
+  for (int idx : rms_index) {
+    if (idx < 0 || idx > 5)
+      throw std::runtime_error("only valid rms indices (x=0, xp=1, y=2, "
+                               "yp=3, z=4, dpp=5) are allowed");
+  }
 
-    karray2d_row correlation_matrix("corr_matrix", 6, 6);
+  karray2d_row correlation_matrix("corr_matrix", 6, 6);
 
-    get_correlation_matrix_host(
-            correlation_matrix.data(),
-            one_turn_map.data(),
-            arms, brms, crms, beta,
-            rms_index);
+  get_correlation_matrix_host(correlation_matrix.data(),
+                              one_turn_map.data(),
+                              arms,
+                              brms,
+                              crms,
+                              beta,
+                              rms_index);
 
-    return correlation_matrix;
+  return correlation_matrix;
 }
 
-
 void
-populate_transverse_gaussian(
-        Distribution& dist, 
-        Bunch& bunch,
-        const_karray1d means, 
-        const_karray2d_row covariances, 
-        double cdt)
+populate_transverse_gaussian(Distribution& dist,
+                             Bunch& bunch,
+                             const_karray1d means,
+                             const_karray2d_row covariances,
+                             double cdt)
 {
-    // deep copy from device to host
-    bunch.checkout_particles();
-    auto particles = bunch.get_host_particles();
+  // deep copy from device to host
+  bunch.checkout_particles();
+  auto particles = bunch.get_host_particles();
 
-    for(int i=0; i<4; ++i)
-    {
-        for(int p=0; p<bunch.size(); ++p)
-            particles(p, i) = dist.get_unit_gaussian();
-    }
+  for (int i = 0; i < 4; ++i) {
+    for (int p = 0; p < bunch.size(); ++p)
+      particles(p, i) = dist.get_unit_gaussian();
+  }
 
-    // cdt
-    for(int p=0; p<bunch.size(); ++p)
-        particles(p, 4) = dist.get_uniform(0.0, 1.0);
+  // cdt
+  for (int p = 0; p < bunch.size(); ++p)
+    particles(p, 4) = dist.get_uniform(0.0, 1.0);
 
-    // dpop
-    for(int p=0; p<bunch.size(); ++p)
-        particles(p, 5) = dist.get_unit_gaussian();
+  // dpop
+  for (int p = 0; p < bunch.size(); ++p)
+    particles(p, 5) = dist.get_unit_gaussian();
 
-    // copy of original means and covariances
-    karray1d means_modified = means;
-    karray2d_row covariances_modified = covariances;
+  // copy of original means and covariances
+  karray1d means_modified("means_modified");
+  karray2d_row covariances_modified("covariances_modified");
 
-    Kokkos::deep_copy(means_modified, means);
-    Kokkos::deep_copy(covariances_modified, covariances);
+  Kokkos::deep_copy(means_modified, means);
+  Kokkos::deep_copy(covariances_modified, covariances);
 
-    means_modified[4] = 0.0;
+  means_modified[4] = 0.0;
 
-    // Symmetry requires no correlations with the cdt coordinate. Make a copy
-    // of the covariance matrix and manually set all correlations to zero.
-    for (int k = 0; k < 6; ++k) 
-        covariances_modified(k, 4) = covariances_modified(4, k) = 0.0;
+  // Symmetry requires no correlations with the cdt coordinate. Make a copy
+  // of the covariance matrix and manually set all correlations to zero.
+  for (int k = 0; k < 6; ++k)
+    covariances_modified(k, 4) = covariances_modified(4, k) = 0.0;
 
-    covariances_modified(4, 4) = cdt*cdt/12.0;
-    adjust_moments(bunch, means_modified, covariances_modified);
+  covariances_modified(4, 4) = cdt * cdt / 12.0;
+  adjust_moments(bunch, means_modified, covariances_modified);
 
-    // copy to device
-    bunch.checkin_particles();
+  // copy to device
+  bunch.checkin_particles();
 }
 
 #if 0
@@ -353,18 +332,18 @@ populate_transverse_KV_GaussLong(Distribution &dist, Bunch &bunch, double epsilM
 // Pick first two points within a 2D circle, flat distribution
       while (d12 > 1.0) {
         x1 = 2.0*dist.get() - 1.0;
-        x2 = 2.0*dist.get() - 1.0; 
+        x2 = 2.0*dist.get() - 1.0;
         d12 = std::sqrt(x1*x1 + x2*x2);
       }
-// Two more       
+// Two more
       double d34 = 2.;
       double x3 = 0.; double x4=0.;
       while (d34 > 1.0) {
         x3 = 2.0*dist.get() - 1.0;
-        x4 = 2.0*dist.get() - 1.0; 
+        x4 = 2.0*dist.get() - 1.0;
         d34 = std::sqrt(x3*x3 + x4*x4);
       }
-// The 4 points on the 4-sphere are x1, x2, z, w 
+// The 4 points on the 4-sphere are x1, x2, z, w
       const double z = x3 * std::sqrt((1.0 - x1*x1 - x2*x2)/(x3*x3 + x4*x4));
       const double w = x4 * std::sqrt((1.0 - x1*x1 - x2*x2)/(x3*x3 + x4*x4));
 // Now move from normal coordinate to physical using lattice functios
@@ -373,7 +352,7 @@ populate_transverse_KV_GaussLong(Distribution &dist, Bunch &bunch, double epsilM
       const double a2X = std::sqrt((x1*x1 + x2*x2) * 4.0 * epsilMax_x*beta_x); // The amplitude.. X physical plane
       particles[part][Bunch::x] = a2X*std::sin(phi2X);
       particles[part][Bunch::xp] = (1.0/beta_x)*(a2X*std::cos(phi2X) - alpha_x*particles[part][Bunch::x]);
-      //  Repeat in y,y' plane 
+      //  Repeat in y,y' plane
       const double phi2Y = std::atan2(w,z);
       const double a2Y = std::sqrt((w*w + z*z) * 4.0 * epsilMax_y*beta_y); // The amplitude..
       particles[part][Bunch::y] = a2Y*std::sin(phi2Y);
@@ -386,29 +365,29 @@ populate_transverse_KV_GaussLong(Distribution &dist, Bunch &bunch, double epsilM
 }
 void
 populate_two_particles(Bunch &bunch,
-         double p1x, double p1xp, double p1y, double p1yp, double p1cdt, double p1dpop, 
+         double p1x, double p1xp, double p1y, double p1yp, double p1cdt, double p1dpop,
          double p2x, double p2xp, double p2y, double p2yp, double p2cdt, double p2dpop) {
     MArray2d_ref particles(bunch.get_local_particles());
     if (bunch.get_local_num() !=2) {
-        std::ostringstream errMsgStream; errMsgStream << "Expecting only two particles when" 
+        std::ostringstream errMsgStream; errMsgStream << "Expecting only two particles when"
 	                                              << bunch.get_local_num() << "generated";
         std::string errMsg(errMsgStream.str());
         throw std::runtime_error(errMsg.c_str());
-    }     
+    }
     particles[0][Bunch::x] = p1x; particles[0][Bunch::xp] = p1xp;
     particles[0][Bunch::y] = p1y; particles[0][Bunch::yp] = p1yp;
     particles[0][Bunch::cdt] = p1cdt; particles[0][Bunch::dpop] = p1dpop;
     particles[1][Bunch::x] = p2x; particles[1][Bunch::xp] = p2xp;
     particles[1][Bunch::y] = p2y; particles[1][Bunch::yp] = p2yp;
     particles[1][Bunch::cdt] = p2cdt; particles[1][Bunch::dpop] = p2dpop;
-} 
+}
 
 
 
 void
 populate_longitudinal_boxcar(Distribution &dist, Bunch &bunch,   Const_MArray2d_ref one_turn_map, double length)
 {
-/// the corelation between the longitudinal and the transverse plane is neglected  
+/// the corelation between the longitudinal and the transverse plane is neglected
 
     double cosmu=0.5*(one_turn_map[Bunch::cdt][Bunch::cdt]+one_turn_map[Bunch::dpop][Bunch::dpop]);
     if (fabs(cosmu)>1.) throw std::runtime_error("longitudinal modes: cosmu larger than zero");
@@ -436,42 +415,42 @@ populate_longitudinal_uniform(Distribution &dist, Bunch &bunch,   double length)
     MArray2d_ref particles(bunch.get_local_particles());
     int num_part = particles.shape()[0];
     dist.fill_uniform(particles[boost::indices[range()][Bunch::cdt]], -half_length, half_length);
-    
+
 }
 
 void
-populate_transverseKV_logitudinalGaussian(Distribution &dist, Bunch &bunch,   Const_MArray2d_ref one_turn_map, 
+populate_transverseKV_logitudinalGaussian(Distribution &dist, Bunch &bunch,   Const_MArray2d_ref one_turn_map,
                              double radiusx,  double radiusy,    double ctrms)
-                             
+
 {
-  
+
 // generates transversally a beam with radii radiusx and radiusy
 // the transverse standard deviations will be xrms=radiusx/2,  yrms=radiusy/2
 // valid for uncoupled linear maps
 
-   double  cosmu=0.5*(one_turn_map[0][0]+one_turn_map[1][1]); 
+   double  cosmu=0.5*(one_turn_map[0][0]+one_turn_map[1][1]);
    if (fabs(cosmu)>1.) throw std::runtime_error("populate KV alpha_x: cosmu larger than zero");
    double sinmu=sqrt(1.-cosmu*cosmu);
    double alpha_x=(one_turn_map[0][0]-cosmu)/sinmu;
    double   beta_x=one_turn_map[0][1]/sinmu;
-   
+
    cosmu=0.5*(one_turn_map[2][2]+one_turn_map[3][3]);
    if (fabs(cosmu)>1.) throw std::runtime_error("populate KV alpha_y: cosmu larger than zero");
    sinmu=sqrt(1.-cosmu*cosmu);
    double alpha_y=(one_turn_map[2][2]-cosmu)/sinmu;
    double beta_y=one_turn_map[2][3]/sinmu;
-   
+
    cosmu=0.5*(one_turn_map[4][4]+one_turn_map[5][5]);
    if (fabs(cosmu)>1.) throw std::runtime_error("populate KV alpha_z: cosmu larger than zero");
    sinmu=sqrt(1.-cosmu*cosmu);
    double alpha_z=(one_turn_map[4][4]-cosmu)/sinmu;
    double beta_z=one_turn_map[4][5]/sinmu;
-   
-   
-  
+
+
+
    MArray2d_ref particles(bunch.get_local_particles());
    int num_part = particles.shape()[0];
-// generate 6 gaussian distributions  
+// generate 6 gaussian distributions
    dist.fill_unit_gaussian(particles[boost::indices[range()][Bunch::x]]);
    dist.fill_unit_gaussian(particles[boost::indices[range()][Bunch::xp]]);
    dist.fill_unit_gaussian(particles[boost::indices[range()][Bunch::y]]);
@@ -483,30 +462,29 @@ populate_transverseKV_logitudinalGaussian(Distribution &dist, Bunch &bunch,   Co
              particles[part][Bunch::xp]*particles[part][Bunch::xp]+
              particles[part][Bunch::y]*particles[part][Bunch::y]+
              particles[part][Bunch::yp]*particles[part][Bunch::yp]   );
-      //transverse distribution       
+      //transverse distribution
       if (r>0.){
         particles[part][Bunch::x] *= radiusx/r;
         particles[part][Bunch::xp] =
               (radiusx*particles[part][Bunch::xp]/r-alpha_x*particles[part][Bunch::x])/beta_x;
-        
-        
+
+
         particles[part][Bunch::y] *= radiusy/r;
         particles[part][Bunch::yp]=
-          (radiusy*particles[part][Bunch::yp]/r-alpha_y*particles[part][Bunch::y])/beta_y;                                       
+          (radiusy*particles[part][Bunch::yp]/r-alpha_y*particles[part][Bunch::y])/beta_y;
       }
       else{ // very unlikely  case, what should be done???
         throw std::runtime_error(
           "generating KV fails, zero radius point for 4d sphere, need to be fixed, try different seed");
-      } 
+      }
      // longitudinal distribution
-    
+
      particles[part][Bunch::z]*= ctrms;
-     particles[part][Bunch::zp]= 
-           (ctrms*particles[part][Bunch::zp]-alpha_z*particles[part][Bunch::z])/beta_z;      
+     particles[part][Bunch::zp]=
+           (ctrms*particles[part][Bunch::zp]-alpha_z*particles[part][Bunch::z])/beta_z;
   } //for part
-  
-  
-  
+
+
+
 }
 #endif
-

--- a/src/synergia/collective/space_charge_2d_open_hockney.cc
+++ b/src/synergia/collective/space_charge_2d_open_hockney.cc
@@ -9,86 +9,75 @@
 #include "synergia/utils/simple_timer.h"
 
 using mconstants::pi;
-using pconstants::epsilon0;
 
-namespace
-{
-    void
-    print_grid( Logger & logger, 
-                karray1d_dev const & grid, 
-                int x0, int x1, 
-                int y0, int y1,
-                int gx, int gy,
-                int off = 0 )
-    {
-        karray1d hgrid = Kokkos::create_mirror_view(grid);
-        Kokkos::deep_copy(hgrid, grid);
+namespace {
+  void
+  print_grid(Logger& logger,
+             karray1d_dev const& grid,
+             int x0,
+             int x1,
+             int y0,
+             int y1,
+             int gx,
+             int gy,
+             int off = 0)
+  {
+    karray1d_hst hgrid = Kokkos::create_mirror_view(grid);
+    Kokkos::deep_copy(hgrid, grid);
 
-        double sum = 0;
+    double sum = 0;
 
-        int dim = grid.extent(0);
-        for(int i=0; i<dim; ++i) sum += hgrid(i);
+    int dim = grid.extent(0);
+    for (int i = 0; i < dim; ++i) sum += hgrid(i);
 
 #if 0
         for(int x=0; x<gx; ++x)
             for(int y=0; y<gy; ++y)
                 sum += hgrid((x*gy + y)*2 + off);
 #endif
-        
-        logger 
-            //<< std::resetiosflags(std::ios::fixed)
-            //<< std::setiosflags(std::ios::showpos | std::ios::scientific)
-            << std::setprecision(12);
 
-        logger << "      " << grid.label() << " = " << sum << "\n";
+    logger
+      //<< std::resetiosflags(std::ios::fixed)
+      //<< std::setiosflags(std::ios::showpos | std::ios::scientific)
+      << std::setprecision(12);
 
-        for(int x=x0; x<x1; ++x)
-        {
-            logger << "        " << x << " | ";
+    logger << "      " << grid.label() << " = " << sum << "\n";
 
-            for (int y=y0; y<y1; ++y)
-            {
-                logger << hgrid((x*gy + y)*2 + off) << ", ";
-            }
+    for (int x = x0; x < x1; ++x) {
+      logger << "        " << x << " | ";
 
-            logger << "\n";
-        }
+      for (int y = y0; y < y1; ++y) {
+        logger << hgrid((x * gy + y) * 2 + off) << ", ";
+      }
+
+      logger << "\n";
+    }
+  }
+
+  double
+  get_smallest_non_tiny(double val, double other1, double other2, double tiny)
+  {
+    double retval;
+    if (val > tiny) {
+      retval = val;
+    } else {
+      if ((other1 > tiny) && (other2 > tiny)) {
+        retval = std::min(other1, other2);
+      } else {
+        retval = std::max(other1, other2);
+      }
     }
 
+    return retval;
+  }
 
-    double
-    get_smallest_non_tiny( double val, 
-                           double other1, 
-                           double other2, 
-                           double tiny )
-    {
-        double retval;
-        if (val > tiny) 
-        {
-            retval = val;
-        } 
-        else 
-        {
-            if ((other1 > tiny) && (other2 > tiny)) 
-            {
-                retval = std::min(other1, other2);
-            } 
-            else 
-            {
-                retval = std::max(other1, other2);
-            }
-        }
-
-        return retval;
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    int fast_int_floor_kokkos(const double x)
-    {
-        int ix = static_cast<int>(x);
-        return x > 0.0 ? ix : ((x - ix == 0) ? ix : ix - 1);
-    }
-
+  KOKKOS_INLINE_FUNCTION
+  int
+  fast_int_floor_kokkos(const double x)
+  {
+    int ix = static_cast<int>(x);
+    return x > 0.0 ? ix : ((x - ix == 0) ? ix : ix - 1);
+  }
 
 #if 0
     inline std::complex<double >
@@ -112,27 +101,27 @@ namespace
         grid_shape[2] = b.shape()[0];
 
         std::complex<double > val;
-        if ( (grid_shape[2] == 1) 
-                && ( (ix >= 0) 
-                    && (ix < grid_shape[0] - 1) 
-                    && (iy >= 0) 
-                    && (iy < grid_shape[1] - 1) ) 
-                && ( periodic_z 
-                    || ( (iz >= 0) && (iz <= grid_shape[2]) ) ) ) 
+        if ( (grid_shape[2] == 1)
+                && ( (ix >= 0)
+                    && (ix < grid_shape[0] - 1)
+                    && (iy >= 0)
+                    && (iy < grid_shape[1] - 1) )
+                && ( periodic_z
+                    || ( (iz >= 0) && (iz <= grid_shape[2]) ) ) )
         {
             double line_density = b[0];
             val = line_density * ((1.0 - offx) * (1.0 - offy) * a[ix][iy]
                     + offx * (1.0 - offy) * a[ix + 1][iy]
                     + (1.0 - offx) * offy * a[ix][iy + 1]
                     + offx * offy * a[ix + 1][iy + 1]);
-        } 
-        else if ( (grid_shape[2] > 1) 
-                && ( (ix >= 0) 
-                    && (ix < grid_shape[0] - 1) 
-                    && (iy >= 0) 
-                    && (iy < grid_shape[1] - 1) ) 
-                && ( periodic_z 
-                    || ( (iz >= 0) && (iz < grid_shape[2] - 1) ) ) ) 
+        }
+        else if ( (grid_shape[2] > 1)
+                && ( (ix >= 0)
+                    && (ix < grid_shape[0] - 1)
+                    && (iy >= 0)
+                    && (iy < grid_shape[1] - 1) )
+                && ( periodic_z
+                    || ( (iz >= 0) && (iz < grid_shape[2] - 1) ) ) )
         {
             double line_density = (1.0 - offz) * b[iz] + offz * b[iz + 1];
             val = line_density * ((1.0 - offx) * (1.0 - offy) * a[ix][iy]
@@ -145,521 +134,492 @@ namespace
     }
 #endif
 
-    struct alg_zeroer
+  struct alg_zeroer {
+    karray1d_dev arr;
+
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        karray1d_dev arr;
+      arr(i) = 0.0;
+    }
+  };
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        { arr(i) = 0.0; }
-    };
+  struct alg_g2_pointlike {
+    const double epsilon = 0.01;
 
-    struct alg_g2_pointlike
+    karray1d_dev g2;
+    int gx, gy;
+    int dgx, dgy;
+    double hx, hy;
+
+    alg_g2_pointlike(karray1d_dev const& g2,
+                     std::array<int, 3> const& g,
+                     std::array<int, 3> const& dg,
+                     std::array<double, 3> const& h)
+      : g2(g2), gx(g[0]), gy(g[1]), dgx(dg[0]), dgy(dg[1]), hx(h[0]), hy(h[1])
+    {}
+
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        const double epsilon = 0.01;
+      int ix = i / dgy;
+      int iy = i - ix * dgy;
 
-        karray1d_dev g2;
-        int gx, gy;
-        int dgx, dgy;
-        double hx, hy;
+      double dx = (ix > gx) ? (ix - dgx) * hx : ix * hx;
+      double dy = (iy > gy) ? (iy - dgy) * hy : iy * hy;
 
-        alg_g2_pointlike(
-                karray1d_dev const & g2,
-                std::array<int, 3> const & g,
-                std::array<int, 3> const & dg,
-                std::array<double, 3> const & h ) 
-            : g2(g2)
-            , gx(g[0]), gy(g[1])
-            , dgx(dg[0]), dgy(dg[1])
-            , hx(h[0]), hy(h[1])
-        { }
+      double Gx, Gy;
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            int ix = i/dgy;
-            int iy = i - ix*dgy;
+      if (ix == gx || iy == gy) {
+        Gx = 0.0;
+        Gy = 0.0;
+      } else {
+        double inv = 1.0 / (dx * dx + dy * dy + hx * hy * epsilon * epsilon);
+        Gx = dx * inv;
+        Gy = dy * inv;
+      }
 
-            double dx = (ix>gx) ? (ix-dgx)*hx : ix*hx;
-            double dy = (iy>gy) ? (iy-dgy)*hy : iy*hy;
+      g2(i * 2) = Gx;
+      g2(i * 2 + 1) = Gy;
+    }
+  };
 
-            double Gx, Gy;
+  struct alg_cplx_multiplier {
+    karray1d_dev prod;
+    karray1d_dev m1, m2;
+    int off;
 
-            if (ix == gx || iy == gy)
-            {
-                Gx = 0.0;
-                Gy = 0.0;
-            }
-            else
-            {
-                double inv = 1.0 / (dx*dx + dy*dy + hx*hy*epsilon*epsilon);
-                Gx = dx * inv;
-                Gy = dy * inv;
-            }
+    alg_cplx_multiplier(karray1d_dev const& prod,
+                        karray1d_dev const& m1,
+                        karray1d_dev const& m2,
+                        int offset)
+      : prod(prod), m1(m1), m2(m2), off(offset)
+    {}
 
-            g2(i*2)   = Gx;
-            g2(i*2+1) = Gy;
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
+    {
+      const int real = (off + i) * 2;
+      const int imag = (off + i) * 2 + 1;
+
+      prod[real] = m1[real] * m2[real] - m1[imag] * m2[imag];
+      prod[imag] = m1[real] * m2[imag] + m1[imag] * m2[real];
+    }
+  };
+
+  struct alg_kicker {
+    Particles p;
+    ConstParticleMasks masks;
+
+    karray1d_dev fn;
+    karray1d_dev rho;
+    karray2d_dev bin;
+
+    int gx, gy, gz;
+    double factor;
+
+    alg_kicker(Particles p,
+               ConstParticleMasks masks,
+               karray1d_dev const& fn,
+               karray1d_dev const& rho,
+               karray2d_dev const& bin,
+               std::array<int, 3> const& g,
+               double factor)
+      : p(p)
+      , masks(masks)
+      , fn(fn)
+      , rho(rho)
+      , bin(bin)
+      , gx(g[0])
+      , gy(g[1])
+      , gz(g[2])
+      , factor(factor)
+    {}
+
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
+    {
+      if (masks(i)) {
+        int ix = fast_int_floor_kokkos(bin(i, 0));
+        int iy = fast_int_floor_kokkos(bin(i, 2));
+        int iz = fast_int_floor_kokkos(bin(i, 4));
+
+        double ox = bin(i, 1);
+        double oy = bin(i, 3);
+        double oz = bin(i, 5);
+
+        double aox = 1.0 - ox;
+        double aoy = 1.0 - oy;
+        double aoz = 1.0 - oz;
+
+        int zbase = gx * gy * 2;
+
+        if ((ix >= 0 && ix < gx - 1) && (iy >= 0 && iy < gy - 1) &&
+            (/*periodic_z ||*/ (iz >= 0 && iz < gz - 1))) {
+          double line_density =
+            aoz * rho(zbase + iz) + oz * rho(zbase + iz + 1);
+
+          double vx =
+            line_density * (aox * aoy * fn(((ix)*gy + (iy)) * 2) +
+                            ox * aoy * fn(((ix + 1) * gy + (iy)) * 2) +
+                            aox * oy * fn(((ix)*gy + (iy + 1)) * 2) +
+                            ox * oy * fn(((ix + 1) * gy + (iy + 1)) * 2));
+
+          double vy =
+            line_density * (aox * aoy * fn(((ix)*gy + (iy)) * 2 + 1) +
+                            ox * aoy * fn(((ix + 1) * gy + (iy)) * 2 + 1) +
+                            aox * oy * fn(((ix)*gy + (iy + 1)) * 2 + 1) +
+                            ox * oy * fn(((ix + 1) * gy + (iy + 1)) * 2 + 1));
+
+          p(i, 1) += factor * vx;
+          p(i, 3) += factor * vy;
         }
-    };
-
-    struct alg_cplx_multiplier
-    {
-        karray1d_dev prod;
-        karray1d_dev m1, m2;
-        int off;
-
-        alg_cplx_multiplier(
-                karray1d_dev const & prod,
-                karray1d_dev const & m1,
-                karray1d_dev const & m2,
-                int offset)
-            : prod(prod), m1(m1), m2(m2), off(offset)
-        { }
-
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            const int real = (off+i)*2;
-            const int imag = (off+i)*2 + 1;
-
-            prod[real] = m1[real]*m2[real] - m1[imag]*m2[imag];
-            prod[imag] = m1[real]*m2[imag] + m1[imag]*m2[real];
-        }
-    };
-
-    struct alg_kicker
-    {
-        Particles p;
-        ConstParticleMasks masks;
-
-        karray1d_dev fn;
-        karray1d_dev rho;
-        karray2d_dev bin;
-
-        int gx, gy, gz;
-        double factor;
-
-        alg_kicker(
-                Particles p,
-                ConstParticleMasks masks,
-                karray1d_dev const & fn,
-                karray1d_dev const & rho,
-                karray2d_dev const & bin,
-                std::array<int, 3> const & g,
-                double factor )
-            : p(p), masks(masks)
-            , fn(fn), rho(rho), bin(bin)
-            , gx(g[0]), gy(g[1]), gz(g[2])
-            , factor(factor)
-        { }
-
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            if (masks(i))
-            {
-                int ix = fast_int_floor_kokkos(bin(i, 0));
-                int iy = fast_int_floor_kokkos(bin(i, 2));
-                int iz = fast_int_floor_kokkos(bin(i, 4));
-
-                double ox = bin(i, 1);
-                double oy = bin(i, 3);
-                double oz = bin(i, 5);
-
-                double aox = 1.0 - ox;
-                double aoy = 1.0 - oy;
-                double aoz = 1.0 - oz;
-
-                int zbase = gx*gy*2;
-
-                if ( ( ix>=0 && ix<gx-1 ) && 
-                     ( iy>=0 && iy<gy-1 ) && 
-                     ( /*periodic_z ||*/ (iz>=0 && iz<gz-1) ) ) 
-                {
-                    double line_density = aoz * rho(zbase+iz) + oz * rho(zbase+iz+1);
-
-                    double vx = line_density * (
-                              aox * aoy * fn( ((ix  )*gy + (iy  ))*2 )
-                            +  ox * aoy * fn( ((ix+1)*gy + (iy  ))*2 )
-                            + aox *  oy * fn( ((ix  )*gy + (iy+1))*2 )
-                            +  ox *  oy * fn( ((ix+1)*gy + (iy+1))*2 ) );
-
-                    double vy = line_density * (
-                              aox * aoy * fn( ((ix  )*gy + (iy  ))*2 + 1 )
-                            +  ox * aoy * fn( ((ix+1)*gy + (iy  ))*2 + 1 )
-                            + aox *  oy * fn( ((ix  )*gy + (iy+1))*2 + 1 )
-                            +  ox *  oy * fn( ((ix+1)*gy + (iy+1))*2 + 1 ) );
-
-                    p(i, 1) += factor * vx;
-                    p(i, 3) += factor * vy;
-                }
-            }
-        }
-    };
+      }
+    }
+  };
 }
-
 
 Space_charge_2d_open_hockney::Space_charge_2d_open_hockney(
-        Space_charge_2d_open_hockney_options const& ops)
-    : Collective_operator("sc_2d_open_hockney", 1.0)
-    , options(ops)
-    , bunch_sim_id()
-    , domain(ops.shape, {1.0, 1.0, 1.0})
-    , doubled_domain(ops.doubled_shape, {1.0, 1.0, 1.0})
-    , particle_bin()
-    , ffts()
+  Space_charge_2d_open_hockney_options const& ops)
+  : Collective_operator("sc_2d_open_hockney", 1.0)
+  , options(ops)
+  , bunch_sim_id()
+  , domain(ops.shape, {1.0, 1.0, 1.0})
+  , doubled_domain(ops.doubled_shape, {1.0, 1.0, 1.0})
+  , particle_bin()
+  , ffts()
+{}
+
+void
+Space_charge_2d_open_hockney::apply_impl(Bunch_simulator& sim,
+                                         double time_step,
+                                         Logger& logger)
 {
-}
+  logger << "    Space charge 2d open hockney\n";
 
-void 
-Space_charge_2d_open_hockney::apply_impl(
-            Bunch_simulator& sim, 
-            double time_step, 
-            Logger& logger)
-{
-    logger << "    Space charge 2d open hockney\n";
+  scoped_simple_timer timer("sc2d_total");
 
-    scoped_simple_timer timer("sc2d_total");
+  // construct the workspace for a new bunch simulator
+  if (bunch_sim_id != sim.id()) {
+    construct_workspaces(sim);
+    bunch_sim_id = sim.id();
+  }
 
-    // construct the workspace for a new bunch simulator
-    if (bunch_sim_id != sim.id())
-    {
-        construct_workspaces(sim);
-        bunch_sim_id = sim.id();
+  // apply to bunches
+  for (size_t t = 0; t < 2; ++t) {
+    for (size_t b = 0; b < sim[t].get_bunch_array_size(); ++b) {
+      apply_bunch(sim[t][b], ffts[t][b], time_step, logger);
     }
-
-    // apply to bunches
-    for(size_t t=0; t<2; ++t)
-    {
-        for(size_t b=0; b<sim[t].get_bunch_array_size(); ++b)
-        {
-            apply_bunch(sim[t][b], ffts[t][b], time_step, logger);
-        }
-    }
+  }
 }
 
 void
-Space_charge_2d_open_hockney::apply_bunch(
-            Bunch& bunch, 
-            Distributed_fft2d& fft,
-            double time_step, 
-            Logger& logger)
+Space_charge_2d_open_hockney::apply_bunch(Bunch& bunch,
+                                          Distributed_fft2d& fft,
+                                          double time_step,
+                                          Logger& logger)
 {
-    update_domain(bunch);
+  update_domain(bunch);
 
-    get_local_charge_density(bunch); // [C/m^3]
-    get_global_charge_density(bunch);
+  get_local_charge_density(bunch); // [C/m^3]
+  get_global_charge_density(bunch);
 
-    get_green_fn2_pointlike();
+  get_green_fn2_pointlike();
 
-    get_local_force2(fft);
-    get_global_force2(fft.get_comm());
+  get_local_force2(fft);
+  get_global_force2(fft.get_comm());
 
-    auto fn_norm = get_normalization_force(bunch, fft);
+  auto fn_norm = get_normalization_force(bunch, fft);
 
-    apply_kick(bunch, fn_norm, time_step);
+  apply_kick(bunch, fn_norm, time_step);
 }
 
 void
-Space_charge_2d_open_hockney::construct_workspaces(
-        Bunch_simulator const& sim)
+Space_charge_2d_open_hockney::construct_workspaces(Bunch_simulator const& sim)
 {
-    scoped_simple_timer timer("sc2d_workspaces");
+  scoped_simple_timer timer("sc2d_workspaces");
 
-    auto const& s = options.doubled_shape;
+  auto const& s = options.doubled_shape;
 
-    rho2 = karray1d_dev("rho2", s[0] * s[1] * 2 + s[2]);
-      g2 = karray1d_dev(  "g2", s[0] * s[1] * 2);
-    phi2 = karray1d_dev("phi2", s[0] * s[1] * 2);
+  rho2 = karray1d_dev("rho2", s[0] * s[1] * 2 + s[2]);
+  g2 = karray1d_dev("g2", s[0] * s[1] * 2);
+  phi2 = karray1d_dev("phi2", s[0] * s[1] * 2);
 
-    h_rho2 = Kokkos::create_mirror_view(rho2);
-    h_phi2 = Kokkos::create_mirror_view(phi2);
+  h_rho2 = Kokkos::create_mirror_view(rho2);
+  h_phi2 = Kokkos::create_mirror_view(phi2);
 
-    for(size_t t=0; t<2; ++t)
-    {
-        int num_local_bunches = sim[t].get_bunch_array_size();
-        ffts[t] = std::vector<Distributed_fft2d>(num_local_bunches);
+  for (size_t t = 0; t < 2; ++t) {
+    int num_local_bunches = sim[t].get_bunch_array_size();
+    ffts[t] = std::vector<Distributed_fft2d>(num_local_bunches);
 
-        for(size_t b=0; b<num_local_bunches; ++b)
-        {
-            auto comm = sim[t][b]
-                .get_comm()
-                .divide(options.comm_group_size);
+    for (size_t b = 0; b < num_local_bunches; ++b) {
+      auto comm = sim[t][b].get_comm().divide(options.comm_group_size);
 
-            ffts[t][b].construct({s[0], s[1]}, comm);
-        }
+      ffts[t][b].construct({s[0], s[1]}, comm);
     }
+  }
 }
- 
+
 void
-Space_charge_2d_open_hockney::update_domain(Bunch const & bunch)
+Space_charge_2d_open_hockney::update_domain(Bunch const& bunch)
 {
-    scoped_simple_timer timer("sc2d_domain");
+  scoped_simple_timer timer("sc2d_domain");
 
-    auto mean = Core_diagnostics::calculate_mean(bunch);
-    auto std  = Core_diagnostics::calculate_std(bunch, mean);
+  auto mean = Core_diagnostics::calculate_mean(bunch);
+  auto std = Core_diagnostics::calculate_std(bunch, mean);
 
-    const double tiny = 1.0e-10;
+  const double tiny = 1.0e-10;
 
-    const auto ix = Bunch::x;
-    const auto iy = Bunch::y;
-    const auto iz = Bunch::z;
+  const auto ix = Bunch::x;
+  const auto iy = Bunch::y;
+  const auto iz = Bunch::z;
 
-    if ( (std[ix] < tiny) && (std[iy] < tiny) && (std[iz] < tiny) ) 
-    {
-        throw std::runtime_error(
-                "Space_charge_3d_open_hockney_eigen::update_domain: "
-                "all three spatial dimensions have neglible extent");
-    }
+  if ((std[ix] < tiny) && (std[iy] < tiny) && (std[iz] < tiny)) {
+    throw std::runtime_error(
+      "Space_charge_3d_open_hockney_eigen::update_domain: "
+      "all three spatial dimensions have neglible extent");
+  }
 
-    std::array<double, 3> offset { 
-        mean[0], 
-        mean[2], 
-        mean[4] };
+  std::array<double, 3> offset{mean[0], mean[2], mean[4]};
 
-    std::array<double, 3> size { 
-        options.n_sigma * get_smallest_non_tiny(std[0], std[2], std[4], tiny),
-        options.n_sigma * get_smallest_non_tiny(std[2], std[0], std[4], tiny),
-        options.n_sigma * get_smallest_non_tiny(std[4], std[0], std[2], tiny) };
+  std::array<double, 3> size{
+    options.n_sigma * get_smallest_non_tiny(std[0], std[2], std[4], tiny),
+    options.n_sigma * get_smallest_non_tiny(std[2], std[0], std[4], tiny),
+    options.n_sigma * get_smallest_non_tiny(std[4], std[0], std[2], tiny)};
 
-    std::array<double, 3> doubled_size { 
-        size[0] * 2.0, 
-        size[1] * 2.0, 
-        size[2] };
+  std::array<double, 3> doubled_size{size[0] * 2.0, size[1] * 2.0, size[2]};
 
-    domain = Rectangular_grid_domain(
-            options.shape, size, offset, false);
+  domain = Rectangular_grid_domain(options.shape, size, offset, false);
 
-    doubled_domain = Rectangular_grid_domain(
-            options.doubled_shape, doubled_size, offset, false);
+  doubled_domain =
+    Rectangular_grid_domain(options.doubled_shape, doubled_size, offset, false);
 }
-
 
 void
 Space_charge_2d_open_hockney::get_local_charge_density(Bunch const& bunch)
 {
-    scoped_simple_timer timer("sc2d_local_rho");
+  scoped_simple_timer timer("sc2d_local_rho");
 
-    if (bunch.size() > particle_bin.extent(0))
-        Kokkos::resize(particle_bin, bunch.size(), 6);
+  if (bunch.size() > particle_bin.extent(0))
+    Kokkos::resize(particle_bin, bunch.size(), 6);
 
 #ifdef KOKKOS_ENABLE_CUDA
-    deposit_charge_rectangular_2d_kokkos_scatter_view(rho2,
-            doubled_domain, particle_bin, bunch);
+  deposit_charge_rectangular_2d_kokkos_scatter_view(
+    rho2, doubled_domain, particle_bin, bunch);
 #else
-    deposit_charge_rectangular_2d_omp_reduce(rho2,
-            doubled_domain, particle_bin, bunch);
+  deposit_charge_rectangular_2d_omp_reduce(
+    rho2, doubled_domain, particle_bin, bunch);
 #endif
 }
 
 void
-Space_charge_2d_open_hockney::get_global_charge_density(
-        Bunch const & bunch )
+Space_charge_2d_open_hockney::get_global_charge_density(Bunch const& bunch)
 {
-    // do nothing if the solver only has a single rank
-    if (bunch.get_comm().size() == 1) return;
+  // do nothing if the solver only has a single rank
+  if (bunch.get_comm().size() == 1) return;
 
-    scoped_simple_timer timer("sc2d_global_rho");
+  scoped_simple_timer timer("sc2d_global_rho");
 
-    auto dg = doubled_domain.get_grid_shape();
+  auto dg = doubled_domain.get_grid_shape();
 
-    simple_timer_start("sc2d_global_rho_copy");
-    Kokkos::deep_copy(h_rho2, rho2);
-    simple_timer_stop("sc2d_global_rho_copy");
+  simple_timer_start("sc2d_global_rho_copy");
+  Kokkos::deep_copy(h_rho2, rho2);
+  simple_timer_stop("sc2d_global_rho_copy");
 
-    simple_timer_start("sc2d_global_rho_reduce");
-    int err = MPI_Allreduce( MPI_IN_PLACE,
-                             (void*)h_rho2.data(), 
-                             dg[0]*dg[1]*2 + dg[2], 
-                             MPI_DOUBLE, 
-                             MPI_SUM, 
-                             bunch.get_comm() );
-    simple_timer_stop("sc2d_global_rho_reduce");
+  simple_timer_start("sc2d_global_rho_reduce");
+  int err = MPI_Allreduce(MPI_IN_PLACE,
+                          (void*)h_rho2.data(),
+                          dg[0] * dg[1] * 2 + dg[2],
+                          MPI_DOUBLE,
+                          MPI_SUM,
+                          bunch.get_comm());
+  simple_timer_stop("sc2d_global_rho_reduce");
 
-    if (err != MPI_SUCCESS)
-    {
-        throw std::runtime_error( 
-                "MPI error in Space_charge_2d_open_hockney"
-                "(MPI_Allreduce in get_global_charge_density)" );
-    }
+  if (err != MPI_SUCCESS) {
+    throw std::runtime_error("MPI error in Space_charge_2d_open_hockney"
+                             "(MPI_Allreduce in get_global_charge_density)");
+  }
 
-    simple_timer_start("sc2d_global_rho_copy");
-    Kokkos::deep_copy(rho2, h_rho2);
-    simple_timer_stop("sc2d_global_rho_copy");
+  simple_timer_start("sc2d_global_rho_copy");
+  Kokkos::deep_copy(rho2, h_rho2);
+  simple_timer_stop("sc2d_global_rho_copy");
 }
-
 
 void
 Space_charge_2d_open_hockney::get_green_fn2_pointlike()
 {
-    scoped_simple_timer timer("sc2d_green_fn2");
+  scoped_simple_timer timer("sc2d_green_fn2");
 
-    auto  g = domain.get_grid_shape();
-    auto  h = doubled_domain.get_cell_size();
-    auto dg = doubled_domain.get_grid_shape();
+  auto g = domain.get_grid_shape();
+  auto h = doubled_domain.get_cell_size();
+  auto dg = doubled_domain.get_grid_shape();
 
-    alg_g2_pointlike alg(g2, g, dg, h);
+  alg_g2_pointlike alg(g2, g, dg, h);
 
-    Kokkos::parallel_for(dg[0]*dg[1], alg);
-    Kokkos::fence();
+  Kokkos::parallel_for(dg[0] * dg[1], alg);
+  Kokkos::fence();
 }
 
 void
 Space_charge_2d_open_hockney::get_local_force2(Distributed_fft2d& fft)
 {
-    scoped_simple_timer timer("sc2d_local_f");
+  scoped_simple_timer timer("sc2d_local_f");
 
-    auto dg = doubled_domain.get_grid_shape();
+  auto dg = doubled_domain.get_grid_shape();
 
-    // FFT
-    fft.transform(rho2, rho2);
-    Kokkos::fence();
+  // FFT
+  fft.transform(rho2, rho2);
+  Kokkos::fence();
 
-    fft.transform(  g2,   g2);
-    Kokkos::fence();
+  fft.transform(g2, g2);
+  Kokkos::fence();
 
-    // zero phi2 when using multiple ranks
-    if (fft.get_comm().size() > 1)
-    {
-        alg_zeroer az{phi2};
-        Kokkos::parallel_for(dg[0]*dg[1]*2, az);
-    }
+  // zero phi2 when using multiple ranks
+  if (fft.get_comm().size() > 1) {
+    alg_zeroer az{phi2};
+    Kokkos::parallel_for(dg[0] * dg[1] * 2, az);
+  }
 
-    int lower = fft.get_lower();
-    int upper = fft.get_upper();
-    int nx = upper - lower;
-    int offset = lower * dg[1];
+  int lower = fft.get_lower();
+  int upper = fft.get_upper();
+  int nx = upper - lower;
+  int offset = lower * dg[1];
 
-    alg_cplx_multiplier alg(phi2, rho2, g2, offset);
-    Kokkos::parallel_for(nx*dg[1], alg);
-    Kokkos::fence();
+  alg_cplx_multiplier alg(phi2, rho2, g2, offset);
+  Kokkos::parallel_for(nx * dg[1], alg);
+  Kokkos::fence();
 
-    // inv fft
-    fft.inv_transform(phi2, phi2);
-    Kokkos::fence();
+  // inv fft
+  fft.inv_transform(phi2, phi2);
+  Kokkos::fence();
 }
 
 void
 Space_charge_2d_open_hockney::get_global_force2(Commxx const& comm)
 {
-    // do nothing if the solver only has a single rank
-    if (comm.size() == 1) return;
+  // do nothing if the solver only has a single rank
+  if (comm.size() == 1) return;
 
-    scoped_simple_timer timer("sc2d_global_f");
+  scoped_simple_timer timer("sc2d_global_f");
 
-    auto dg = doubled_domain.get_grid_shape();
+  auto dg = doubled_domain.get_grid_shape();
 
-    Kokkos::deep_copy(h_phi2, phi2);
+  Kokkos::deep_copy(h_phi2, phi2);
 
-    int err = MPI_Allreduce( MPI_IN_PLACE,
-                             (void*)h_phi2.data(), 
-                             dg[0]*dg[1]*2, 
-                             MPI_DOUBLE, 
-                             MPI_SUM, 
-                             comm );
+  int err = MPI_Allreduce(MPI_IN_PLACE,
+                          (void*)h_phi2.data(),
+                          dg[0] * dg[1] * 2,
+                          MPI_DOUBLE,
+                          MPI_SUM,
+                          comm);
 
-    if (err != MPI_SUCCESS)
-    {
-        throw std::runtime_error( 
-                "MPI error in Space_charge_2d_open_hockney"
-                "(MPI_Allreduce in get_global_electric_force2_allreduce)" );
-    }
+  if (err != MPI_SUCCESS) {
+    throw std::runtime_error(
+      "MPI error in Space_charge_2d_open_hockney"
+      "(MPI_Allreduce in get_global_electric_force2_allreduce)");
+  }
 
-    Kokkos::deep_copy(phi2, h_phi2);
+  Kokkos::deep_copy(phi2, h_phi2);
 }
 
 double
 Space_charge_2d_open_hockney::get_normalization_force(
-        Bunch const & bunch, Distributed_fft2d const& fft)
+  Bunch const& bunch,
+  Distributed_fft2d const& fft)
 {
-    auto h = domain.get_cell_size();
+  auto h = domain.get_cell_size();
 
-    double hx = h[0];
-    double hy = h[1];
-    double hz = h[2];
+  double hx = h[0];
+  double hy = h[1];
+  double hz = h[2];
 
-    // volume element in integral
-    double normalization = hx * hy;
+  // volume element in integral
+  double normalization = hx * hy;
 
-    // dummy factor from weight0 of deposit.cc
-    normalization *= 1.0 / (4.0 * pi * pconstants::epsilon0);
-    normalization *= hz;
+  // dummy factor from weight0 of deposit.cc
+  normalization *= 1.0 / (4.0 * pi * pconstants::epsilon0);
+  normalization *= hz;
 
-    // average line density for real particles
-    normalization *= 1.0 / doubled_domain.get_physical_size()[2];
+  // average line density for real particles
+  normalization *= 1.0 / doubled_domain.get_physical_size()[2];
 
-    // average line density for macro particles
-    normalization *= 2.0 * doubled_domain.get_physical_size()[2] 
-        / (hz * bunch.get_total_num());
+  // average line density for macro particles
+  normalization *=
+    2.0 * doubled_domain.get_physical_size()[2] / (hz * bunch.get_total_num());
 
-    normalization *= bunch.get_particle_charge() * pconstants::e;
+  normalization *= bunch.get_particle_charge() * pconstants::e;
 
-    normalization *= 1.0; //charge_density2.get_normalization();
-    normalization *= 1.0; //green_fn2.get_normalization();
+  normalization *= 1.0; // charge_density2.get_normalization();
+  normalization *= 1.0; // green_fn2.get_normalization();
 
-    normalization *= fft.get_roundtrip_normalization();
+  normalization *= fft.get_roundtrip_normalization();
 
-    return normalization;
+  return normalization;
 }
 
 void
-Space_charge_2d_open_hockney::apply_kick(
-        Bunch & bunch,
-        double fn_norm,
-        double time_step )
+Space_charge_2d_open_hockney::apply_kick(Bunch& bunch,
+                                         double fn_norm,
+                                         double time_step)
 {
-    scoped_simple_timer timer("sc2d_kick");
+  scoped_simple_timer timer("sc2d_kick");
 
-    // EGS ported AM changes for kicks in lab frame from 3D solver
-    // AM: kicks are done in the z_lab frame
-    // $\delta \vec{p} = \vec{F} \delta t = q \vec{E} \delta t$
-    // delta_t_beam: [s] in beam frame
-    //  See chapter 11, jackson electrodynamics, for field transformation 
-    //  from bunch frame (BF) to the lab frame (LF). Keep in mind that 
-    //  \vec{B}_BF=0.
-    //  Ex_LF=gamma*Ex_BF, Ey_LF=gamma*Ey_BF, Ez_LF=Ez_BF
-    //  Bx_LF=gamma*beta*Ey_BF, By_LF=-gamma*beta*Ex_BF, Bz_LF=Bz_BF=0
-    //  Transverse Lorentz force in the lab frame: 
-    //        Fx_LF = q*(Ex_L-beta_z*By_LF)
-    //              = q*gamma*(1-beta*beta_z)*Ex_BF
-    //  Longitudinal Lorentz force in the lab frame:
-    //        Fz = q*(Ez_LF+beta_x*By_LF-beta_y*Bx_LF)
-    //           = q*(Ez_BF-gamma*beta*(beta_x*Ex_BF+beta_y*Ey_BF ))
-    // In order to get a conservative approximation!:
-    // The following approximations are done: beta_z=beta, beta_x=beta_y=0, 
-    // thus suppresing the particles' movement relative to the reference 
-    // particle. The same approximation was employed when the field in 
-    // the bunch frame was calculated.
-    // Thus: Fx_LF=q*Ex_BF/gamma, Fz=q*Ez_BF
+  // EGS ported AM changes for kicks in lab frame from 3D solver
+  // AM: kicks are done in the z_lab frame
+  // $\delta \vec{p} = \vec{F} \delta t = q \vec{E} \delta t$
+  // delta_t_beam: [s] in beam frame
+  //  See chapter 11, jackson electrodynamics, for field transformation
+  //  from bunch frame (BF) to the lab frame (LF). Keep in mind that
+  //  \vec{B}_BF=0.
+  //  Ex_LF=gamma*Ex_BF, Ey_LF=gamma*Ey_BF, Ez_LF=Ez_BF
+  //  Bx_LF=gamma*beta*Ey_BF, By_LF=-gamma*beta*Ex_BF, Bz_LF=Bz_BF=0
+  //  Transverse Lorentz force in the lab frame:
+  //        Fx_LF = q*(Ex_L-beta_z*By_LF)
+  //              = q*gamma*(1-beta*beta_z)*Ex_BF
+  //  Longitudinal Lorentz force in the lab frame:
+  //        Fz = q*(Ez_LF+beta_x*By_LF-beta_y*Bx_LF)
+  //           = q*(Ez_BF-gamma*beta*(beta_x*Ex_BF+beta_y*Ey_BF ))
+  // In order to get a conservative approximation!:
+  // The following approximations are done: beta_z=beta, beta_x=beta_y=0,
+  // thus suppresing the particles' movement relative to the reference
+  // particle. The same approximation was employed when the field in
+  // the bunch frame was calculated.
+  // Thus: Fx_LF=q*Ex_BF/gamma, Fz=q*Ez_BF
 
-    double delta_t_beam = time_step / bunch.get_reference_particle().get_gamma();
+  double delta_t_beam = time_step / bunch.get_reference_particle().get_gamma();
 
-    // unit_conversion: [N] = [kg m/s^2] to [Gev/c]
-    double unit_conversion = pconstants::c / (1.0e9 * pconstants::e);
+  // unit_conversion: [N] = [kg m/s^2] to [Gev/c]
+  double unit_conversion = pconstants::c / (1.0e9 * pconstants::e);
 
-    // scaled p = p/p_ref
-    double gamma = bunch.get_reference_particle().get_gamma();
-    double beta = bunch.get_reference_particle().get_beta();
-    double p_scale = 1.0 / bunch.get_reference_particle().get_momentum();
+  // scaled p = p/p_ref
+  double gamma = bunch.get_reference_particle().get_gamma();
+  double beta = bunch.get_reference_particle().get_beta();
+  double p_scale = 1.0 / bunch.get_reference_particle().get_momentum();
 
-    // gamma*beta factor introduced here when we are no longer going to 
-    // the t_bunch frame. That factor was introduced in the fixed_z_lab 
-    // to fixed_t_bunch conversion.  Physically, gamma factor comes from 
-    // the lorentz expansion longitudinally in the bunch frame and beta 
-    // comes because the stored coordinate is c*dt whereas the actual
-    // domain is beta*c*dt.
-    double factor = unit_conversion * delta_t_beam * fn_norm * p_scale 
-                    / (gamma * beta);
+  // gamma*beta factor introduced here when we are no longer going to
+  // the t_bunch frame. That factor was introduced in the fixed_z_lab
+  // to fixed_t_bunch conversion.  Physically, gamma factor comes from
+  // the lorentz expansion longitudinally in the bunch frame and beta
+  // comes because the stored coordinate is c*dt whereas the actual
+  // domain is beta*c*dt.
+  double factor =
+    unit_conversion * delta_t_beam * fn_norm * p_scale / (gamma * beta);
 
-    auto parts = bunch.get_local_particles();
-    auto masks = bunch.get_local_particle_masks();
+  auto parts = bunch.get_local_particles();
+  auto masks = bunch.get_local_particle_masks();
 
-    alg_kicker kicker(parts, masks, phi2, rho2, particle_bin,
-            doubled_domain.get_grid_shape(), factor);
+  alg_kicker kicker(parts,
+                    masks,
+                    phi2,
+                    rho2,
+                    particle_bin,
+                    doubled_domain.get_grid_shape(),
+                    factor);
 
-    Kokkos::parallel_for(bunch.size(), kicker);
-    Kokkos::fence();
+  Kokkos::parallel_for(bunch.size(), kicker);
+  Kokkos::fence();
 }
-
-
-

--- a/src/synergia/collective/space_charge_3d_open_hockney.cc
+++ b/src/synergia/collective/space_charge_3d_open_hockney.cc
@@ -24,7 +24,7 @@ namespace {
              int gz,
              int off = 0)
   {
-    karray1d hgrid = Kokkos::create_mirror_view(grid);
+    karray1d_hst hgrid = Kokkos::create_mirror_view(grid);
     Kokkos::deep_copy(hgrid, grid);
 
     double sum = 0;

--- a/src/synergia/collective/space_charge_rectangular.cc
+++ b/src/synergia/collective/space_charge_rectangular.cc
@@ -1,632 +1,622 @@
 #include "synergia/collective/space_charge_rectangular.h"
+#include "deposit.h"
+#include "synergia/bunch/core_diagnostics.h"
 #include "synergia/foundation/math_constants.h"
 #include "synergia/foundation/physical_constants.h"
-#include "synergia/bunch/core_diagnostics.h"
-#include "deposit.h"
 
 #include "synergia/utils/simple_timer.h"
 
-using mconstants::pi;
-using pconstants::epsilon0;
+namespace {
+  void
+  print_grid(Logger& logger,
+             karray1d_dev const& grid,
+             int x0,
+             int x1,
+             int y0,
+             int y1,
+             int z0,
+             int z1,
+             int gx,
+             int gy,
+             int gz,
+             int off = 0)
+  {
+    karray1d_hst hgrid = Kokkos::create_mirror_view(grid);
+    Kokkos::deep_copy(hgrid, grid);
 
-namespace
-{
-    void
-    print_grid( Logger & logger, 
-                karray1d_dev const & grid, 
-                int x0, int x1, 
-                int y0, int y1,
-                int z0, int z1,
-                int gx, int gy, int gz,
-                int off = 0 )
-    {
-        karray1d hgrid = Kokkos::create_mirror_view(grid);
-        Kokkos::deep_copy(hgrid, grid);
+    double sum = 0;
 
-        double sum = 0;
-
-        int dim = grid.extent(0);
-        for(int i=0; i<dim; ++i) 
-        {
-            sum += fabs(hgrid(i));
-        }
+    int dim = grid.extent(0);
+    for (int i = 0; i < dim; ++i) { sum += fabs(hgrid(i)); }
 
 #if 0
         for(int x=0; x<gx; ++x)
             for(int y=0; y<gy; ++y)
                 sum += hgrid((x*gy + y)*2 + off);
 #endif
-        
-        logger << std::setprecision(12) << std::scientific;
-        logger << "      " << grid.label() << ".sum = " << sum << "\n";
 
-        for (int z=z0; z<z1; ++z)
-        {
-            logger << "        " << z << ", ";
+    logger << std::setprecision(12) << std::scientific;
+    logger << "      " << grid.label() << ".sum = " << sum << "\n";
 
-            for (int y=y0; y<y1; ++y)
-            {
-                logger << y << ", " << x0 << " | ";
+    for (int z = z0; z < z1; ++z) {
+      logger << "        " << z << ", ";
 
-                for (int x=x0; x<x1; ++x)
-                {
-                    logger << std::setprecision(12) 
-                        //<< hgrid(z*gx*gy + y*gx + x) << ", ";
-                        << hgrid(x*gy*gz + y*gz + z) << ", ";
-                }
+      for (int y = y0; y < y1; ++y) {
+        logger << y << ", " << x0 << " | ";
 
-                logger << "\n";
-            }
+        for (int x = x0; x < x1; ++x) {
+          logger << std::setprecision(12)
+                 //<< hgrid(z*gx*gy + y*gx + x) << ", ";
+                 << hgrid(x * gy * gz + y * gz + z) << ", ";
         }
-    }
-
-    void print_statistics(Bunch & bunch, Logger & logger)
-    {
-
-        logger
-            << "Bunch statistics: "
-            << "num_valid = " << bunch.get_local_num()
-            << ", size = " << bunch.size()
-            << ", capacity = " << bunch.capacity()
-            << ", total_num = " << bunch.get_total_num()
-            <<"\nMean and std: ";
-
-
-        // print particles after propagate
-        auto mean = Core_diagnostics::calculate_mean(bunch);
-        auto std  = Core_diagnostics::calculate_std(bunch, mean);
-
-        logger
-            << std::setprecision(16)
-            << std::showpos << std::scientific
-            << "\n"
-            //<< "\nmean\tstd\n"
-            ;
-
-        for (int i=0; i<6; ++i) 
-            logger << mean[i] << ", " << std[i] << "\n";
 
         logger << "\n";
-
-        for (int p=0; p<4; ++p) bunch.print_particle(p, logger);
-
-        logger << "\n";
+      }
     }
+  }
+
+  void
+  print_statistics(Bunch& bunch, Logger& logger)
+  {
+
+    logger << "Bunch statistics: "
+           << "num_valid = " << bunch.get_local_num()
+           << ", size = " << bunch.size() << ", capacity = " << bunch.capacity()
+           << ", total_num = " << bunch.get_total_num() << "\nMean and std: ";
+
+    // print particles after propagate
+    auto mean = Core_diagnostics::calculate_mean(bunch);
+    auto std = Core_diagnostics::calculate_std(bunch, mean);
+
+    logger << std::setprecision(16) << std::showpos << std::scientific << "\n"
+      //<< "\nmean\tstd\n"
+      ;
+
+    for (int i = 0; i < 6; ++i) logger << mean[i] << ", " << std[i] << "\n";
+
+    logger << "\n";
+
+    for (int p = 0; p < 4; ++p) bunch.print_particle(p, logger);
+
+    logger << "\n";
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  int
+  fast_int_floor_kokkos(const double x)
+  {
+    int ix = static_cast<int>(x);
+    return x > 0.0 ? ix : ((x - ix == 0) ? ix : ix - 1);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void
+  get_leftmost_indices_offset(double pos,
+                              double left,
+                              double inv_cell_size,
+                              int& idx,
+                              double& off)
+  {
+    double scaled_location = (pos - left) * inv_cell_size - 0.5;
+    idx = fast_int_floor_kokkos(scaled_location);
+    off = scaled_location - idx;
+  }
+
+  struct alg_zeroer {
+    karray1d_dev arr;
 
     KOKKOS_INLINE_FUNCTION
-    int fast_int_floor_kokkos(const double x)
+    void
+    operator()(const int i) const
     {
-        int ix = static_cast<int>(x);
-        return x > 0.0 ? ix : ((x - ix == 0) ? ix : ix - 1);
+      arr(i) = 0.0;
     }
+  };
+
+  struct alg_phi {
+    karray1d_dev phi;
+    int lower, gy, gz;
+    double igygz, igz;
+    double px, py, pz;
+    double gamma;
+
+    alg_phi(karray1d_dev const& phi,
+            int lower,
+            int gy,
+            int gz,
+            double px,
+            double py,
+            double pz,
+            double gamma)
+      : phi(phi)
+      , lower(lower)
+      , gy(gy)
+      , gz(gz)
+      , igygz(1.0 / (gy * gz))
+      , igz(1.0 / gz)
+      , px(px)
+      , py(py)
+      , pz(pz)
+      , gamma(gamma)
+    {}
 
     KOKKOS_INLINE_FUNCTION
-    void get_leftmost_indices_offset(
-            double pos, double left, double inv_cell_size,
-            int & idx, double & off )
+    void
+    operator()(const int i) const
     {
-        double scaled_location = (pos - left) * inv_cell_size - 0.5;
-        idx = fast_int_floor_kokkos(scaled_location);
-        off = scaled_location - idx;
+      const int ix = i * igygz;
+      const int iy = (i - ix * gy * gz) * igz;
+      const int iz = i - ix * gy * gz - iy * gz;
+
+      int xt = ix + lower + 1;
+      int yt = iy + 1;
+
+      double denominator = mconstants::pi * mconstants::pi *
+                           (xt * xt / (px * px) + yt * yt / (py * py) +
+                            4.0 * iz * iz / (pz * pz * gamma * gamma));
+
+      int base = ix * gy * gz + iy * gz + iz;
+
+      phi(base * 2 + 0) /= denominator;
+      phi(base * 2 + 1) /= denominator;
     }
+  };
 
-    struct alg_zeroer
+  struct alg_force_extractor {
+    karray1d_dev phi;
+    karray1d_dev enx;
+    karray1d_dev eny;
+    karray1d_dev enz;
+
+    int gx, gy, gz;
+    int dgx, dgy;
+    double ihx, ihy, ihz;
+    double igygz;
+    double igz;
+
+    alg_force_extractor(karray1d_dev const& phi,
+                        karray1d_dev const& enx,
+                        karray1d_dev const& eny,
+                        karray1d_dev const& enz,
+                        std::array<int, 3> const& g,
+                        std::array<double, 3> const& h)
+      : phi(phi)
+      , enx(enx)
+      , eny(eny)
+      , enz(enz)
+      , gx(g[0])
+      , gy(g[1])
+      , gz(g[2])
+      , ihx(0.5 / h[0])
+      , ihy(0.5 / h[1])
+      , ihz(0.5 / h[2])
+      , igygz(1.0 / (gy * gz))
+      , igz(1.0 / gz)
+    {}
+
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        karray1d_dev arr;
+      int ix = i * igygz;
+      int iy = (i - ix * gy * gz) * igz;
+      int iz = i - ix * gy * gz - iy * gz;
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        { arr(i) = 0.0; }
-    };
+      int ixl, ixr, iyl, iyr, izl, izr;
+      double idx, idy, idz;
 
-    struct alg_phi
+      // all x-y boundaries will be skipped (set to 0)
+      if (ix == 0 || ix == gx - 1 || iy == 0 || iy == gy - 1) return;
+
+      ixl = ix - 1;
+      ixr = ix + 1;
+      iyl = iy - 1;
+      iyr = iy + 1;
+      izl = iz - 1;
+      izr = iz + 1;
+
+      idx = ihx;
+      idy = ihy;
+      idz = ihz;
+
+      // periodic z
+      if (iz == 0) {
+        izl = gz - 1;
+      } else if (iz == gz - 1) {
+        izr = 0;
+      }
+
+      int idx_r = ixr * gy * gz + iy * gz + iz;
+      int idx_l = ixl * gy * gz + iy * gz + iz;
+      enx(i) = -(phi(idx_r) - phi(idx_l)) * idx;
+
+      idx_r = ix * gy * gz + iyr * gz + iz;
+      idx_l = ix * gy * gz + iyl * gz + iz;
+      eny(i) = -(phi(idx_r) - phi(idx_l)) * idy;
+
+      idx_r = ix * gy * gz + iy * gz + izr;
+      idx_l = ix * gy * gz + iy * gz + izl;
+      enz(i) = -(phi(idx_r) - phi(idx_l)) * idz;
+    }
+  };
+
+  struct alg_kicker {
+    Particles parts;
+    ConstParticleMasks masks;
+
+    karray1d_dev enx;
+    karray1d_dev eny;
+    karray1d_dev enz;
+
+    int gx, gy, gz;
+    double ihx, ihy, ihz;
+    double lx, ly, lz;
+    double factor, pref, m;
+
+    alg_kicker(Particles parts,
+               ConstParticleMasks masks,
+               karray1d_dev const& enx,
+               karray1d_dev const& eny,
+               karray1d_dev const& enz,
+               std::array<int, 3> const& g,
+               std::array<double, 3> const& h,
+               std::array<double, 3> const& l,
+               double factor,
+               double pref,
+               double m)
+      : parts(parts)
+      , masks(masks)
+      , enx(enx)
+      , eny(eny)
+      , enz(enz)
+      , gx(g[0])
+      , gy(g[1])
+      , gz(g[2])
+      , ihx(1.0 / h[0])
+      , ihy(1.0 / h[1])
+      , ihz(1.0 / h[2])
+      , lx(l[0])
+      , ly(l[1])
+      , lz(l[2])
+      , factor(factor)
+      , pref(pref)
+      , m(m)
+    {}
+
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        karray1d_dev phi;
-        int lower, gy, gz;
-        double igygz, igz;
-        double px, py, pz;
-        double gamma;
+      if (masks(i)) {
+        int ix, iy, iz;
+        double ox, oy, oz;
 
-        alg_phi(karray1d_dev const& phi,
-                int lower, int gy, int gz,
-                double px, double py, double pz,
-                double gamma)
-            : phi(phi)
-            , lower(lower), gy(gy), gz(gz)
-            , igygz(1.0/(gy*gz))
-            , igz(1.0/gz)
-            , px(px), py(py), pz(pz)
-            , gamma(gamma)
-        { }
+        get_leftmost_indices_offset(parts(i, 0), lx, ihx, ix, ox);
+        get_leftmost_indices_offset(parts(i, 2), ly, ihy, iy, oy);
+        get_leftmost_indices_offset(parts(i, 4), lz, ihz, iz, oz);
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            const int ix = i * igygz;
-            const int iy = (i - ix*gy*gz) * igz;
-            const int iz = i - ix*gy*gz - iy*gz;
+        double aox = 1.0 - ox;
+        double aoy = 1.0 - oy;
+        double aoz = 1.0 - oz;
 
-            int xt = ix + lower + 1;
-            int yt = iy + 1;
+        if (ix >= 0 && ix < gx - 1 && iy >= 0 && iy < gy - 1) {
+          while (iz > gz - 1) iz -= gz;
+          while (iz < 0) iz += gz;
 
-            double denominator 
-                = mconstants::pi * mconstants::pi * ( 
-                        xt*xt / (px*px) + 
-                        yt*yt / (py*py) + 
-                        4.0 * iz*iz / (pz*pz*gamma*gamma) );
+          int izp1 = (iz == (gz - 1)) ? 0 : iz + 1;
 
-            int base = ix*gy*gz + iy*gz + iz;
+          double val = 0;
+          int base = 0;
 
-            phi(base*2+0) /= denominator;
-            phi(base*2+1) /= denominator;
+          // enz
+          base = ix * gy * gz + iy * gz;
+          val = aox * aoy * aoz * enz(base + iz);       // x, y, z
+          val += aox * aoy * oz * enz(base + izp1);     // x, y, z+1
+          val += aox * oy * aoz * enz(base + gz + iz);  // x, y+1, z
+          val += aox * oy * oz * enz(base + gz + izp1); // x, y+1, z+1
 
+          base = (ix + 1) * gy * gz + iy * gz;
+          val += ox * aoy * aoz * enz(base + iz);      // x+1, y, z
+          val += ox * aoy * oz * enz(base + izp1);     // x+1, y, z+1
+          val += ox * oy * aoz * enz(base + gz + iz);  // x+1, y+1, z
+          val += ox * oy * oz * enz(base + gz + izp1); // x+1, y+1, z+1
+
+          double p = pref + parts(i, 5) * pref;
+          double Eoc_i = std::sqrt(p * p + m * m);
+          double Eoc_f = Eoc_i - factor * pref * val;
+          double dpop = (std::sqrt(Eoc_f * Eoc_f - m * m) -
+                         std::sqrt(Eoc_i * Eoc_i - m * m)) /
+                        pref;
+
+          parts(i, 5) += dpop;
+
+          // eny
+          base = ix * gy * gz + iy * gz;
+          val = aox * aoy * aoz * eny(base + iz);       // x, y, z
+          val += aox * aoy * oz * eny(base + izp1);     // x, y, z+1
+          val += aox * oy * aoz * eny(base + gz + iz);  // x, y+1, z
+          val += aox * oy * oz * eny(base + gz + izp1); // x, y+1, z+1
+
+          base = (ix + 1) * gy * gz + iy * gz;
+          val += ox * aoy * aoz * eny(base + iz);      // x+1, y, z
+          val += ox * aoy * oz * eny(base + izp1);     // x+1, y, z+1
+          val += ox * oy * aoz * eny(base + gz + iz);  // x+1, y+1, z
+          val += ox * oy * oz * eny(base + gz + izp1); // x+1, y+1, z+1
+
+          parts(i, 3) += factor * val;
+
+          // enx
+          base = ix * gy * gz + iy * gz;
+          val = aox * aoy * aoz * enx(base + iz);       // x, y, z
+          val += aox * aoy * oz * enx(base + izp1);     // x, y, z+1
+          val += aox * oy * aoz * enx(base + gz + iz);  // x, y+1, z
+          val += aox * oy * oz * enx(base + gz + izp1); // x, y+1, z+1
+
+          base = (ix + 1) * gy * gz + iy * gz;
+          val += ox * aoy * aoz * enx(base + iz);      // x+1, y, z
+          val += ox * aoy * oz * enx(base + izp1);     // x+1, y, z+1
+          val += ox * oy * aoz * enx(base + gz + iz);  // x+1, y+1, z
+          val += ox * oy * oz * enx(base + gz + izp1); // x+1, y+1, z+1
+
+          parts(i, 1) += factor * val;
         }
-    };
-
-    struct alg_force_extractor
-    {
-        karray1d_dev phi;
-        karray1d_dev enx;
-        karray1d_dev eny;
-        karray1d_dev enz;
-
-        int gx, gy, gz;
-        int dgx, dgy;
-        double ihx, ihy, ihz;
-        double igygz;
-        double igz;
-
-        alg_force_extractor(
-                karray1d_dev const& phi,
-                karray1d_dev const& enx,
-                karray1d_dev const& eny,
-                karray1d_dev const& enz,
-                std::array<int, 3> const& g,
-                std::array<double, 3> const& h )
-            : phi(phi), enx(enx), eny(eny), enz(enz)
-            , gx(g[0]), gy(g[1]), gz(g[2])
-            , ihx(0.5/h[0]), ihy(0.5/h[1]), ihz(0.5/h[2])
-            , igygz(1.0/(gy*gz))
-            , igz(1.0/gz)
-        { }
-
-
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            int ix = i * igygz;
-            int iy = (i - ix*gy*gz) * igz;
-            int iz = i - ix*gy*gz - iy*gz;
-
-            int ixl, ixr, iyl, iyr, izl, izr;
-            double idx, idy, idz;
-
-            // all x-y boundaries will be skipped (set to 0)
-            if (ix==0 || ix==gx-1 || iy==0 || iy==gy-1)
-                return;
-
-            ixl = ix - 1; ixr = ix + 1;
-            iyl = iy - 1; iyr = iy + 1;
-            izl = iz - 1; izr = iz + 1;
-
-            idx = ihx; idy = ihy; idz = ihz;
-
-            // periodic z
-            if (iz==0) { izl = gz-1; }
-            else if (iz==gz-1) { izr = 0; }
-
-            int idx_r = ixr*gy*gz + iy*gz + iz;
-            int idx_l = ixl*gy*gz + iy*gz + iz;
-            enx(i) = -(phi(idx_r) - phi(idx_l)) * idx;
-
-            idx_r = ix*gy*gz + iyr*gz + iz;
-            idx_l = ix*gy*gz + iyl*gz + iz;
-            eny(i) = -(phi(idx_r) - phi(idx_l)) * idy;
-
-            idx_r = ix*gy*gz + iy*gz + izr;
-            idx_l = ix*gy*gz + iy*gz + izl;
-            enz(i) = -(phi(idx_r) - phi(idx_l)) * idz;
-        }
-    };
-
-    struct alg_kicker
-    {
-        Particles parts;
-        ConstParticleMasks masks;
-
-        karray1d_dev enx;
-        karray1d_dev eny;
-        karray1d_dev enz;
-
-        int gx, gy, gz;
-        double ihx, ihy, ihz;
-        double lx, ly, lz;
-        double factor, pref, m;
-
-        alg_kicker(
-                Particles parts,
-                ConstParticleMasks masks,
-                karray1d_dev const& enx,
-                karray1d_dev const& eny,
-                karray1d_dev const& enz,
-                std::array<int,    3> const& g,
-                std::array<double, 3> const& h,
-                std::array<double, 3> const& l,
-                double factor,
-                double pref,
-                double m )
-            : parts(parts), masks(masks)
-            , enx(enx), eny(eny), enz(enz)
-            , gx(g[0]), gy(g[1]), gz(g[2])
-            , ihx(1.0/h[0]), ihy(1.0/h[1]), ihz(1.0/h[2])
-            , lx(l[0]), ly(l[1]), lz(l[2])
-            , factor(factor), pref(pref), m(m)
-        { }
-
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            if (masks(i))
-            {
-                int ix, iy, iz;
-                double ox, oy, oz;
-
-                get_leftmost_indices_offset(parts(i, 0), lx, ihx, ix, ox);
-                get_leftmost_indices_offset(parts(i, 2), ly, ihy, iy, oy);
-                get_leftmost_indices_offset(parts(i, 4), lz, ihz, iz, oz);
-
-                double aox = 1.0 - ox;
-                double aoy = 1.0 - oy;
-                double aoz = 1.0 - oz;
-
-                if (ix>=0 && ix<gx-1 && iy>=0 && iy<gy-1)
-                {
-                    while (iz > gz-1) iz -= gz;
-                    while (iz < 0) iz += gz;
-
-                    int izp1 = (iz==(gz-1)) ? 0 : iz + 1;
-
-                    double val = 0;
-                    int base = 0;
-
-                    // enz
-                    base = ix*gy*gz + iy*gz;
-                    val  = aox * aoy * aoz * enz(base+iz);      // x, y, z
-                    val += aox * aoy *  oz * enz(base+izp1);    // x, y, z+1
-                    val += aox *  oy * aoz * enz(base+gz+iz);   // x, y+1, z
-                    val += aox *  oy *  oz * enz(base+gz+izp1); // x, y+1, z+1
-
-                    base = (ix+1)*gy*gz + iy*gz;
-                    val += ox * aoy * aoz * enz(base+iz);       // x+1, y, z
-                    val += ox * aoy *  oz * enz(base+izp1);     // x+1, y, z+1
-                    val += ox *  oy * aoz * enz(base+gz+iz);    // x+1, y+1, z
-                    val += ox *  oy *  oz * enz(base+gz+izp1);  // x+1, y+1, z+1
-
-                    double p = pref + parts(i, 5) * pref;
-                    double Eoc_i = std::sqrt(p*p+m*m);
-                    double Eoc_f = Eoc_i - factor * pref * val;
-                    double dpop = (std::sqrt(Eoc_f*Eoc_f-m*m) - std::sqrt(Eoc_i*Eoc_i-m*m))/pref;
-
-                    parts(i, 5) += dpop;
-
-                    // eny
-                    base = ix*gy*gz + iy*gz;
-                    val  = aox * aoy * aoz * eny(base+iz);      // x, y, z
-                    val += aox * aoy *  oz * eny(base+izp1);    // x, y, z+1
-                    val += aox *  oy * aoz * eny(base+gz+iz);   // x, y+1, z
-                    val += aox *  oy *  oz * eny(base+gz+izp1); // x, y+1, z+1
-
-                    base = (ix+1)*gy*gz + iy*gz;
-                    val += ox * aoy * aoz * eny(base+iz);       // x+1, y, z
-                    val += ox * aoy *  oz * eny(base+izp1);     // x+1, y, z+1
-                    val += ox *  oy * aoz * eny(base+gz+iz);    // x+1, y+1, z
-                    val += ox *  oy *  oz * eny(base+gz+izp1);  // x+1, y+1, z+1
-
-                    parts(i, 3) += factor * val;
-
-                    // enx
-                    base = ix*gy*gz + iy*gz;
-                    val  = aox * aoy * aoz * enx(base+iz);      // x, y, z
-                    val += aox * aoy *  oz * enx(base+izp1);    // x, y, z+1
-                    val += aox *  oy * aoz * enx(base+gz+iz);   // x, y+1, z
-                    val += aox *  oy *  oz * enx(base+gz+izp1); // x, y+1, z+1
-
-                    base = (ix+1)*gy*gz + iy*gz;
-                    val += ox * aoy * aoz * enx(base+iz);       // x+1, y, z
-                    val += ox * aoy *  oz * enx(base+izp1);     // x+1, y, z+1
-                    val += ox *  oy * aoz * enx(base+gz+iz);    // x+1, y+1, z
-                    val += ox *  oy *  oz * enx(base+gz+izp1);  // x+1, y+1, z+1
-
-                    parts(i, 1) += factor * val;
-                }
-            }
-        }
-    };
+      }
+    }
+  };
 
 }
-
-
-
 
 Space_charge_rectangular::Space_charge_rectangular(
-            Space_charge_rectangular_options const& ops)
-    : Collective_operator("sc_rectangular", 1.0)
-    , options(ops)
-    , domain(ops.shape, {1.0, 1.0, 1.0})
-    , ffts()
+  Space_charge_rectangular_options const& ops)
+  : Collective_operator("sc_rectangular", 1.0)
+  , options(ops)
+  , domain(ops.shape, {1.0, 1.0, 1.0})
+  , ffts()
+{}
+
+void
+Space_charge_rectangular::apply_impl(Bunch_simulator& sim,
+                                     double time_step,
+                                     Logger& logger)
 {
-}
+  logger << "    Space charge 3d open hockney\n";
 
+  scoped_simple_timer timer("sc_rect_total");
 
-void 
-Space_charge_rectangular::apply_impl(
-            Bunch_simulator& sim, 
-            double time_step, 
-            Logger& logger)
-{
-    logger << "    Space charge 3d open hockney\n";
+  // construct the workspace for a new bunch simulator
+  if (bunch_sim_id != sim.id()) {
+    construct_workspaces(sim);
+    bunch_sim_id = sim.id();
+  }
 
-    scoped_simple_timer timer("sc_rect_total");
-
-    // construct the workspace for a new bunch simulator
-    if (bunch_sim_id != sim.id())
-    {
-        construct_workspaces(sim);
-        bunch_sim_id = sim.id();
+  // apply to bunches
+  for (size_t t = 0; t < 2; ++t) {
+    for (size_t b = 0; b < sim[t].get_bunch_array_size(); ++b) {
+      apply_bunch(sim[t][b], ffts[t][b], time_step, logger);
     }
-
-    // apply to bunches
-    for(size_t t=0; t<2; ++t)
-    {
-        for(size_t b=0; b<sim[t].get_bunch_array_size(); ++b)
-        {
-            apply_bunch(sim[t][b], ffts[t][b], time_step, logger);
-        }
-    }
-
+  }
 }
 
 void
-Space_charge_rectangular::apply_bunch(
-            Bunch& bunch, 
-            Distributed_fft3d_rect& fft,
-            double time_step, 
-            Logger& logger)
+Space_charge_rectangular::apply_bunch(Bunch& bunch,
+                                      Distributed_fft3d_rect& fft,
+                                      double time_step,
+                                      Logger& logger)
 {
-    update_domain(bunch);
+  update_domain(bunch);
 
-    get_local_charge_density(bunch);
-    get_global_charge_density(bunch);
+  get_local_charge_density(bunch);
+  get_global_charge_density(bunch);
 
-    double gamma = bunch.get_reference_particle().get_gamma();
+  double gamma = bunch.get_reference_particle().get_gamma();
 
-    get_local_phi(fft, gamma);
-    get_global_phi(fft);
+  get_local_phi(fft, gamma);
+  get_global_phi(fft);
 
-    auto fn_norm = get_normalization_force();
+  auto fn_norm = get_normalization_force();
 
-    extract_force();
-    apply_kick(bunch, fn_norm, time_step);
+  extract_force();
+  apply_kick(bunch, fn_norm, time_step);
 }
 
 void
-Space_charge_rectangular::construct_workspaces(
-        Bunch_simulator const& sim)
+Space_charge_rectangular::construct_workspaces(Bunch_simulator const& sim)
 {
-    // shape
-    auto const& s = options.shape;
+  // shape
+  auto const& s = options.shape;
 
-    // fft objects
-    for(size_t t=0; t<2; ++t)
-    {
-        int num_local_bunches = sim[t].get_bunch_array_size();
-        ffts[t] = std::vector<Distributed_fft3d_rect>(num_local_bunches);
+  // fft objects
+  for (size_t t = 0; t < 2; ++t) {
+    int num_local_bunches = sim[t].get_bunch_array_size();
+    ffts[t] = std::vector<Distributed_fft3d_rect>(num_local_bunches);
 
-        for(size_t b=0; b<num_local_bunches; ++b)
-        {
-            auto comm = sim[t][b]
-                .get_comm()
-                .divide(options.comm_group_size);
+    for (size_t b = 0; b < num_local_bunches; ++b) {
+      auto comm = sim[t][b].get_comm().divide(options.comm_group_size);
 
-            ffts[t][b].construct(s, comm);
-        }
+      ffts[t][b].construct(s, comm);
     }
+  }
 
-    // local workspaces
-    int nz_cplx = Distributed_fft3d_rect::get_padded_shape_cplx(s[2]);
+  // local workspaces
+  int nz_cplx = Distributed_fft3d_rect::get_padded_shape_cplx(s[2]);
 
-    rho = karray1d_dev("rho", s[0] * s[1] * s[2]);
-    phi = karray1d_dev("phi", s[0] * s[1] * s[2]);
+  rho = karray1d_dev("rho", s[0] * s[1] * s[2]);
+  phi = karray1d_dev("phi", s[0] * s[1] * s[2]);
 
-    phihat = karray1d_dev("phihat", s[0] * s[1] * nz_cplx*2);
+  phihat = karray1d_dev("phihat", s[0] * s[1] * nz_cplx * 2);
 
-    h_rho = Kokkos::create_mirror_view(rho);
-    h_phi = Kokkos::create_mirror_view(phi);
+  h_rho = Kokkos::create_mirror_view(rho);
+  h_phi = Kokkos::create_mirror_view(phi);
 
-    // En is in the original domain
-    enx = karray1d_dev("enx", s[0] * s[1] * s[2]);
-    eny = karray1d_dev("eny", s[0] * s[1] * s[2]);
-    enz = karray1d_dev("enz", s[0] * s[1] * s[2]);
+  // En is in the original domain
+  enx = karray1d_dev("enx", s[0] * s[1] * s[2]);
+  eny = karray1d_dev("eny", s[0] * s[1] * s[2]);
+  enz = karray1d_dev("enz", s[0] * s[1] * s[2]);
 }
-
 
 void
 Space_charge_rectangular::update_domain(Bunch const& bunch)
 {
-    double beta = bunch.get_reference_particle().get_beta();
-    auto dsize = options.pipe_size;
-    dsize[2] /= beta;    // size in z_lab frame, longitudinal cdt coordinate
+  double beta = bunch.get_reference_particle().get_beta();
+  auto dsize = options.pipe_size;
+  dsize[2] /= beta; // size in z_lab frame, longitudinal cdt coordinate
 
-    // A.M physical_offsets of the domain should be rescaled too, 
-    // but in this case they are zero    
-    domain = Rectangular_grid_domain(
-            options.shape, dsize, {0.0, 0.0, 0.0}, true);
+  // A.M physical_offsets of the domain should be rescaled too,
+  // but in this case they are zero
+  domain = Rectangular_grid_domain(options.shape, dsize, {0.0, 0.0, 0.0}, true);
 }
 
 void
 Space_charge_rectangular::get_local_charge_density(Bunch const& bunch)
 {
-    scoped_simple_timer timer("sc_rect_local_rho");
+  scoped_simple_timer timer("sc_rect_local_rho");
 
-    auto g = domain.get_grid_shape();
-    //g[2] = Distributed_fft3d::get_padded_shape_real(g[2]);
-    //g[2] = (g[2]/2+1)*2;
+  auto g = domain.get_grid_shape();
+  // g[2] = Distributed_fft3d::get_padded_shape_real(g[2]);
+  // g[2] = (g[2]/2+1)*2;
 
 #ifdef KOKKOS_ENABLE_OPENMP
-    deposit_charge_rectangular_3d_omp_reduce_xyz(rho,
-            domain, g, bunch);
+  deposit_charge_rectangular_3d_omp_reduce_xyz(rho, domain, g, bunch);
 #else
-    deposit_charge_rectangular_3d_kokkos_scatter_view_xyz(rho,
-            domain, g, bunch);
+  deposit_charge_rectangular_3d_kokkos_scatter_view_xyz(rho, domain, g, bunch);
 #endif
 }
-
 
 void
 Space_charge_rectangular::get_global_charge_density(Bunch const& bunch)
 {
-    // do nothing if the bunch occupis a single rank
-    if (bunch.get_comm().size() == 1) return;
+  // do nothing if the bunch occupis a single rank
+  if (bunch.get_comm().size() == 1) return;
 
-    scoped_simple_timer timer("sc_rect_global_rho");
+  scoped_simple_timer timer("sc_rect_global_rho");
 
-    auto g = domain.get_grid_shape();
+  auto g = domain.get_grid_shape();
 
-    simple_timer_start("sc_rect_global_rho_copy");
-    Kokkos::deep_copy(h_rho, rho);
-    simple_timer_stop("sc_rect_global_rho_copy");
+  simple_timer_start("sc_rect_global_rho_copy");
+  Kokkos::deep_copy(h_rho, rho);
+  simple_timer_stop("sc_rect_global_rho_copy");
 
-    simple_timer_start("sc_rect_global_rho_reduce");
-    int err = MPI_Allreduce( MPI_IN_PLACE,
-                             (void*)h_rho.data(), 
-                             h_rho.extent(0),
-                             MPI_DOUBLE, 
-                             MPI_SUM, 
-                             bunch.get_comm() );
-    simple_timer_stop("sc_rect_global_rho_reduce");
+  simple_timer_start("sc_rect_global_rho_reduce");
+  int err = MPI_Allreduce(MPI_IN_PLACE,
+                          (void*)h_rho.data(),
+                          h_rho.extent(0),
+                          MPI_DOUBLE,
+                          MPI_SUM,
+                          bunch.get_comm());
+  simple_timer_stop("sc_rect_global_rho_reduce");
 
-    if (err != MPI_SUCCESS)
-    {
-        throw std::runtime_error( 
-                "MPI error in Space_charge_rectangular"
-                "(MPI_Allreduce in get_global_charge_density)" );
-    }
+  if (err != MPI_SUCCESS) {
+    throw std::runtime_error("MPI error in Space_charge_rectangular"
+                             "(MPI_Allreduce in get_global_charge_density)");
+  }
 
-    simple_timer_start("sc_rect_global_rho_copy");
-    Kokkos::deep_copy(rho, h_rho);
-    simple_timer_stop("sc_rect_global_rho_copy");
-}
-
-
-void
-Space_charge_rectangular::get_local_phi(
-        Distributed_fft3d_rect& fft, double gamma)
-{
-    scoped_simple_timer timer("sc_rect_local_phi");
-
-    alg_zeroer az{phihat};
-    Kokkos::parallel_for(phihat.extent(0), az);
-
-    fft.transform(rho, phihat);
-
-    int lower = fft.get_lower();
-    int upper = fft.get_upper();
-    auto ps = options.pipe_size;
-    auto g = domain.get_grid_shape();
-    int gy = g[1];
-    int gz_padded_cplx = g[2]/2 + 1;
-
-    alg_phi aphi(phihat, lower, gy, gz_padded_cplx,
-            ps[0], ps[1], ps[2], gamma);
-
-    Kokkos::parallel_for(
-            (upper-lower)*gy*gz_padded_cplx, aphi);
-
-    fft.inv_transform(phihat, phi);
+  simple_timer_start("sc_rect_global_rho_copy");
+  Kokkos::deep_copy(rho, h_rho);
+  simple_timer_stop("sc_rect_global_rho_copy");
 }
 
 void
-Space_charge_rectangular::get_global_phi(
-        Distributed_fft3d_rect const& fft)
+Space_charge_rectangular::get_local_phi(Distributed_fft3d_rect& fft,
+                                        double gamma)
 {
-    // do nothing if the solver only has a single rank
-    if (fft.get_comm().size() == 1) return;
+  scoped_simple_timer timer("sc_rect_local_phi");
 
-    scoped_simple_timer timer("sc_rect_global_phi");
+  alg_zeroer az{phihat};
+  Kokkos::parallel_for(phihat.extent(0), az);
 
-    Kokkos::deep_copy(h_phi, phi);
+  fft.transform(rho, phihat);
 
-    int err = MPI_Allreduce( MPI_IN_PLACE,
-                             (void*)h_phi.data(), 
-                             h_phi.extent(0),
-                             MPI_DOUBLE, 
-                             MPI_SUM, 
-                             fft.get_comm() );
+  int lower = fft.get_lower();
+  int upper = fft.get_upper();
+  auto ps = options.pipe_size;
+  auto g = domain.get_grid_shape();
+  int gy = g[1];
+  int gz_padded_cplx = g[2] / 2 + 1;
 
-    if (err != MPI_SUCCESS)
-    {
-        throw std::runtime_error( 
-                "MPI error in Space_charge_3d_open_hockney"
-                "(MPI_Allreduce in get_global_electric_force2_allreduce)" );
-    }
+  alg_phi aphi(phihat, lower, gy, gz_padded_cplx, ps[0], ps[1], ps[2], gamma);
 
-    Kokkos::deep_copy(phi, h_phi);
+  Kokkos::parallel_for((upper - lower) * gy * gz_padded_cplx, aphi);
+
+  fft.inv_transform(phihat, phi);
+}
+
+void
+Space_charge_rectangular::get_global_phi(Distributed_fft3d_rect const& fft)
+{
+  // do nothing if the solver only has a single rank
+  if (fft.get_comm().size() == 1) return;
+
+  scoped_simple_timer timer("sc_rect_global_phi");
+
+  Kokkos::deep_copy(h_phi, phi);
+
+  int err = MPI_Allreduce(MPI_IN_PLACE,
+                          (void*)h_phi.data(),
+                          h_phi.extent(0),
+                          MPI_DOUBLE,
+                          MPI_SUM,
+                          fft.get_comm());
+
+  if (err != MPI_SUCCESS) {
+    throw std::runtime_error(
+      "MPI error in Space_charge_3d_open_hockney"
+      "(MPI_Allreduce in get_global_electric_force2_allreduce)");
+  }
+
+  Kokkos::deep_copy(phi, h_phi);
 }
 
 double
 Space_charge_rectangular::get_normalization_force()
 {
-    auto g = domain.get_grid_shape();
-    return 1.0 / (4.0 * g[0] * g[1] * g[2] * pconstants::epsilon0);
+  auto g = domain.get_grid_shape();
+  return 1.0 / (4.0 * g[0] * g[1] * g[2] * pconstants::epsilon0);
 }
 
 void
 Space_charge_rectangular::extract_force()
 {
-    scoped_simple_timer timer("sc_rect_get_en");
+  scoped_simple_timer timer("sc_rect_get_en");
 
-    auto g = domain.get_grid_shape();
-    auto h = domain.get_cell_size();
+  auto g = domain.get_grid_shape();
+  auto h = domain.get_cell_size();
 
-    // phi is in (gx, gy, gz)
-    // en{x|y|z} is in (gx, gy, gz)
-    alg_force_extractor alg(phi, enx, eny, enz, g, h);
-    Kokkos::parallel_for(g[0]*g[1]*g[2], alg);
-    Kokkos::fence();
+  // phi is in (gx, gy, gz)
+  // en{x|y|z} is in (gx, gy, gz)
+  alg_force_extractor alg(phi, enx, eny, enz, g, h);
+  Kokkos::parallel_for(g[0] * g[1] * g[2], alg);
+  Kokkos::fence();
 }
 
 void
-Space_charge_rectangular::apply_kick(
-        Bunch& bunch,
-        double fn_norm,
-        double time_step)
+Space_charge_rectangular::apply_kick(Bunch& bunch,
+                                     double fn_norm,
+                                     double time_step)
 {
-    scoped_simple_timer timer("sc_rect_kick");
+  scoped_simple_timer timer("sc_rect_kick");
 
-    auto ref = bunch.get_reference_particle();
+  auto ref = bunch.get_reference_particle();
 
-    double q = bunch.get_particle_charge() * pconstants::e;
-    double m = bunch.get_mass();
+  double q = bunch.get_particle_charge() * pconstants::e;
+  double m = bunch.get_mass();
 
-    double gamma = ref.get_gamma();
-    double beta  = ref.get_beta();
-    double pref  = ref.get_momentum();
+  double gamma = ref.get_gamma();
+  double beta = ref.get_beta();
+  double pref = ref.get_momentum();
 
-    double unit_conversion = pconstants::c / (1e9 * pconstants::e);
-    double factor = unit_conversion * q * time_step * fn_norm 
-        / (pref * gamma * gamma * beta);
+  double unit_conversion = pconstants::c / (1e9 * pconstants::e);
+  double factor =
+    unit_conversion * q * time_step * fn_norm / (pref * gamma * gamma * beta);
 
-    auto parts = bunch.get_local_particles();
-    auto masks = bunch.get_local_particle_masks();
+  auto parts = bunch.get_local_particles();
+  auto masks = bunch.get_local_particle_masks();
 
-    auto g = domain.get_grid_shape();
-    auto h = domain.get_cell_size();
-    auto l = domain.get_left();
+  auto g = domain.get_grid_shape();
+  auto h = domain.get_cell_size();
+  auto l = domain.get_left();
 
-    alg_kicker kicker(parts, masks, enx, eny, enz,
-            g, h, l, factor, pref, m);
+  alg_kicker kicker(parts, masks, enx, eny, enz, g, h, l, factor, pref, m);
 
-    Kokkos::parallel_for(bunch.size(), kicker);
-    Kokkos::fence();
+  Kokkos::parallel_for(bunch.size(), kicker);
+  Kokkos::fence();
 }
-

--- a/src/synergia/utils/distributed_fft3d_rect_cuda.cc
+++ b/src/synergia/utils/distributed_fft3d_rect_cuda.cc
@@ -1,545 +1,589 @@
-#include <cstring>
-#include <stdexcept>
 #include "distributed_fft3d_rect.h"
 #include "synergia/foundation/math_constants.h"
+#include <cstring>
+#include <stdexcept>
 
-namespace 
-{
-    void print(karray1d_dev const& arr)
+namespace {
+  void
+  print(karray1d_dev const& arr)
+  {
+    karray1d_hst harr = Kokkos::create_mirror_view(arr);
+    Kokkos::deep_copy(harr, arr);
+
+    std::cout << harr.label() << "\n  ";
+
+    for (int i = 0; i < harr.extent(0); ++i) std::cout << harr(i) << ", ";
+
+    std::cout << "\n";
+  }
+
+  struct alg_zeroer {
+    karray1d_dev arr;
+
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        karray1d harr = Kokkos::create_mirror_view(arr);
-        Kokkos::deep_copy(harr, arr);
-
-        std::cout << harr.label() << "\n  ";
-
-        for(int i=0; i<harr.extent(0); ++i)
-            std::cout << harr(i) << ", ";
-
-        std::cout << "\n";
+      arr(i) = 0.0;
     }
+  };
 
-    struct alg_zeroer
+  void
+  zero(karray1d_dev const& arr)
+  {
+    alg_zeroer alg{arr};
+    Kokkos::parallel_for(arr.extent(0), alg);
+  }
+
+  struct alg_pad_x {
+    // in: (x, y, z) of (gx, gy, gz) double
+    // out: (z, y, x) of (gz, gy, gx*2) complex
+    karray1d_dev in;
+    karray1d_dev out;
+
+    int dgx, gy, gz;
+    double igygz;
+    double igz;
+
+    alg_pad_x(karray1d_dev const& in,
+              karray1d_dev const& out,
+              std::array<int, 3> const& g)
+      : in(in)
+      , out(out)
+      , dgx(2 * g[0])
+      , gy(g[1])
+      , gz(g[2])
+      , igygz(1.0 / (gy * gz))
+      , igz(1.0 / gz)
+    {}
+
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        karray1d_dev arr;
+      int ix = i * igygz;
+      int iy = (i - ix * gy * gz) * igz;
+      int iz = i - ix * gy * gz - iy * gz;
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        { arr(i) = 0.0; }
-    };
-
-    void zero(karray1d_dev const& arr)
-    {
-        alg_zeroer alg{arr};
-        Kokkos::parallel_for(arr.extent(0), alg);
+      // { 1, 2, 3 } ->
+      // { 1, 0, 2, 0, 3, 0, -3, 0, -2, 0, -1, 0 }
+      out((iz * gy * dgx + iy * dgx + ix) * 2) = in(i);
+      out((iz * gy * dgx + iy * dgx + dgx - 1 - ix) * 2) = -in(i);
     }
+  };
 
-    struct alg_pad_x
+  struct alg_pad_y {
+    // in: (z, y, x) of (gz, gy, gx*2) complex
+    // out: (z, x, y) of (gz, gx, gy*2) complex
+    karray1d_dev in;
+    karray1d_dev out;
+
+    int gx, gy;
+    int dgx, dgy;
+    double igxgy;
+    double igx;
+
+    alg_pad_y(karray1d_dev const& in,
+              karray1d_dev const& out,
+              std::array<int, 3> const& g)
+      : in(in)
+      , out(out)
+      , gx(g[0])
+      , gy(g[1])
+      , dgx(2 * g[0])
+      , dgy(2 * g[1])
+      , igxgy(1.0 / (gy * gx))
+      , igx(1.0 / gx)
+    {}
+
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        // in: (x, y, z) of (gx, gy, gz) double
-        // out: (z, y, x) of (gz, gy, gx*2) complex
-        karray1d_dev in;
-        karray1d_dev out;
+      int iz = i * igxgy;
+      int iy = (i - iz * gy * gx) * igx;
+      int ix = i - iz * gy * gx - iy * gx;
 
-        int dgx, gy, gz;
-        double igygz;
-        double igz;
+      // { 1, 2, 3 } ->
+      // { 1, 0, 2, 0, 3, 0, -3, 0, -2, 0, -1, 0 }
+      out((iz * gx * dgy + ix * dgy + iy) * 2) =
+        -in((iz * gy * dgx + iy * dgx + ix + 1) * 2 + 1);
 
-        alg_pad_x(
-                karray1d_dev const& in,
-                karray1d_dev const& out,
-                std::array<int, 3> const& g )
-            : in(in), out(out)
-            , dgx(2*g[0]), gy(g[1]), gz(g[2])
-            , igygz(1.0/(gy*gz))
-            , igz(1.0/gz)
-        { }
+      out((iz * gx * dgy + ix * dgy + dgy - 1 - iy) * 2) =
+        in((iz * gy * dgx + iy * dgx + ix + 1) * 2 + 1);
+    }
+  };
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            int ix = i * igygz;
-            int iy = (i - ix*gy*gz) * igz;
-            int iz = i - ix*gy*gz - iy*gz;
+  struct alg_pad_z {
+    // in: (z, x, y) of (gz, gx, gy*2) complex
+    // out: (x, y, z) of (gx, gy, gz) double
+    karray1d_dev in;
+    karray1d_dev out;
 
-            // { 1, 2, 3 } -> 
-            // { 1, 0, 2, 0, 3, 0, -3, 0, -2, 0, -1, 0 }
-            out((iz*gy*dgx + iy*dgx + ix)*2) = in(i);
-            out((iz*gy*dgx + iy*dgx + dgx-1-ix)*2) = -in(i);
-        }
-    };
+    int gx, gy, gz;
+    int dgy;
+    double igxgy;
+    double igx;
 
-    struct alg_pad_y
+    alg_pad_z(karray1d_dev const& in,
+              karray1d_dev const& out,
+              std::array<int, 3> const& g)
+      : in(in)
+      , out(out)
+      , gx(g[0])
+      , gy(g[1])
+      , gz(g[2])
+      , dgy(g[1] * 2)
+      , igxgy(1.0 / (gx * gy))
+      , igx(1.0 / gx)
+    {}
+
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        // in: (z, y, x) of (gz, gy, gx*2) complex
-        // out: (z, x, y) of (gz, gx, gy*2) complex
-        karray1d_dev in;
-        karray1d_dev out;
+      int iz = i * igxgy;
+      int iy = (i - iz * gy * gx) * igx;
+      int ix = i - iz * gy * gx - iy * gx;
 
-        int gx, gy;
-        int dgx, dgy;
-        double igxgy;
-        double igx;
+      out(ix * gy * gz + iy * gz + iz) =
+        -in((iz * gx * dgy + ix * dgy + iy + 1) * 2 + 1);
+    }
+  };
 
-        alg_pad_y(
-                karray1d_dev const& in,
-                karray1d_dev const& out,
-                std::array<int, 3> const& g )
-            : in(in), out(out)
-            , gx(g[0]), gy(g[1])
-            , dgx(2*g[0]), dgy(2*g[1])
-            , igxgy(1.0/(gy*gx))
-            , igx(1.0/gx)
-        { }
+  struct alg_inv_pad_y {
+    // in: (x, y, z) of (gx, gy, gz) double
+    // out: (z, x, y) of (gz, gx, gy*2) complex
+    karray1d_dev in;
+    karray1d_dev out;
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            int iz = i * igxgy;
-            int iy = (i - iz*gy*gx) * igx;
-            int ix = i - iz*gy*gx - iy*gx;
+    int gx, gy, gz;
+    int dgy;
+    double igygz;
+    double igz;
 
-            // { 1, 2, 3 } -> 
-            // { 1, 0, 2, 0, 3, 0, -3, 0, -2, 0, -1, 0 }
-            out((iz*gx*dgy + ix*dgy + iy)*2) 
-                = -in((iz*gy*dgx + iy*dgx + ix+1)*2+1);
+    alg_inv_pad_y(karray1d_dev const& in,
+                  karray1d_dev const& out,
+                  std::array<int, 3> const& g)
+      : in(in)
+      , out(out)
+      , gx(g[0])
+      , gy(g[1])
+      , gz(g[2])
+      , dgy(2 * g[1])
+      , igygz(1.0 / (gy * gz))
+      , igz(1.0 / gz)
+    {}
 
-            out((iz*gx*dgy + ix*dgy + dgy-1-iy)*2) 
-                = in((iz*gy*dgx + iy*dgx + ix+1)*2+1);
-        }
-    };
-
-    struct alg_pad_z
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        // in: (z, x, y) of (gz, gx, gy*2) complex
-        // out: (x, y, z) of (gx, gy, gz) double
-        karray1d_dev in;
-        karray1d_dev out;
+      int ix = i * igygz;
+      int iy = (i - ix * gy * gz) * igz;
+      int iz = i - ix * gy * gz - iy * gz;
 
-        int gx, gy, gz;
-        int dgy;
-        double igxgy;
-        double igx;
+      // { 1, 2, 3 } ->
+      // { 0, 0, 0, 1, 0, 2, 0, 3, 0, 2, 0, 1 }
+      int out_idx = iz * gx * dgy + ix * dgy + iy + 1;
 
-        alg_pad_z(
-                karray1d_dev const& in,
-                karray1d_dev const& out,
-                std::array<int, 3> const& g )
-            : in(in), out(out)
-            , gx(g[0]), gy(g[1]), gz(g[2])
-            , dgy(g[1]*2)
-            , igxgy(1.0/(gx*gy))
-            , igx(1.0/gx)
-        { }
+      out(out_idx * 2 + 0) = 0.0;
+      out(out_idx * 2 + 1) = in(ix * gy * gz + iy * gz + iz);
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            int iz = i * igxgy;
-            int iy = (i - iz*gy*gx) * igx;
-            int ix = i - iz*gy*gx - iy*gx;
+      // mirror
+      if (iy == gy - 1) {
+        out_idx = iz * gx * dgy + ix * dgy + 0;
+        out(out_idx * 2 + 0) = 0.0;
+        out(out_idx * 2 + 1) = 0.0;
+      } else {
+        out_idx = iz * gx * dgy + ix * dgy + dgy - 1 - iy;
 
-            out(ix*gy*gz + iy*gz + iz)
-                = -in((iz*gx*dgy + ix*dgy + iy+1)*2 + 1);
-        }
-    };
+        out(out_idx * 2 + 0) = 0.0;
+        out(out_idx * 2 + 1) = in(ix * gy * gz + iy * gz + iz);
+      }
+    }
+  };
 
-    struct alg_inv_pad_y
+  struct alg_inv_pad_x {
+    // in: (z, x, y) of (gz, gx, gy*2) complex
+    // out: (z, y, x) of (gz, gy, gx*2) complex
+    karray1d_dev in;
+    karray1d_dev out;
+
+    int gx, gy;
+    int dgx, dgy;
+    double igxgy;
+    double igy;
+
+    alg_inv_pad_x(karray1d_dev const& in,
+                  karray1d_dev const& out,
+                  std::array<int, 3> const& g)
+      : in(in)
+      , out(out)
+      , gx(g[0])
+      , gy(g[1])
+      , dgx(2 * g[0])
+      , dgy(2 * g[1])
+      , igxgy(1.0 / (gx * gy))
+      , igy(1.0 / gy)
+    {}
+
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        // in: (x, y, z) of (gx, gy, gz) double 
-        // out: (z, x, y) of (gz, gx, gy*2) complex
-        karray1d_dev in;
-        karray1d_dev out;
+      int iz = i * igxgy;
+      int ix = (i - iz * gx * gy) * igy;
+      int iy = i - iz * gx * gy - ix * gy;
 
-        int gx, gy, gz;
-        int dgy;
-        double igygz;
-        double igz;
+      // { 1, 2, 3 } ->
+      // { 0, 0, 0, 1, 0, 2, 0, 3, 0, 2, 0, 1 }
+      int out_idx = iz * gy * dgx + iy * dgx + ix + 1;
+      int in_idx = iz * gx * dgy + ix * dgy + iy;
 
-        alg_inv_pad_y(
-                karray1d_dev const& in,
-                karray1d_dev const& out,
-                std::array<int, 3> const& g )
-            : in(in), out(out)
-            , gx(g[0]), gy(g[1]), gz(g[2])
-            , dgy(2*g[1])
-            , igygz(1.0/(gy*gz))
-            , igz(1.0/gz)
-        { }
+      out(out_idx * 2 + 0) = 0.0;
+      out(out_idx * 2 + 1) = -in(in_idx * 2 + 0);
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            int ix = i * igygz;
-            int iy = (i - ix*gy*gz) * igz;
-            int iz = i - ix*gy*gz - iy*gz;
+      // mirror
+      out_idx = (ix == gx - 1) ? (iz * gy * dgx + iy * dgx + 0) :
+                                 (iz * gy * dgx + iy * dgx + dgx - 1 - ix);
 
-            // { 1, 2, 3 } -> 
-            // { 0, 0, 0, 1, 0, 2, 0, 3, 0, 2, 0, 1 }
-            int out_idx = iz*gx*dgy + ix*dgy + iy+1;
+      out(out_idx * 2 + 0) = 0.0;
+      out(out_idx * 2 + 1) = -in(in_idx * 2 + 0);
+    }
+  };
 
-            out(out_idx*2 + 0) = 0.0;
-            out(out_idx*2 + 1) = in(ix*gy*gz + iy*gz + iz);
+  struct alg_inv_pad_z {
+    // in: (z, y, x) of (gz, gy, gx*2) complex
+    // out: (x, y, z) of (gx, gy, gz) double
+    karray1d_dev in;
+    karray1d_dev out;
 
-            // mirror
-            if (iy == gy-1)
-            {
-                out_idx = iz*gx*dgy + ix*dgy + 0;
-                out(out_idx*2 + 0) = 0.0;
-                out(out_idx*2 + 1) = 0.0;
-            }
-            else
-            {
-                out_idx = iz*gx*dgy + ix*dgy + dgy-1-iy;
+    int gx, gy, gz;
+    int dgx;
+    double igxgy;
+    double igx;
 
-                out(out_idx*2 + 0) = 0.0;
-                out(out_idx*2 + 1) = in(ix*gy*gz + iy*gz + iz);
-            }
-        }
-    };
+    alg_inv_pad_z(karray1d_dev const& in,
+                  karray1d_dev const& out,
+                  std::array<int, 3> const& g)
+      : in(in)
+      , out(out)
+      , gx(g[0])
+      , gy(g[1])
+      , gz(g[2])
+      , dgx(g[0] * 2)
+      , igxgy(1.0 / (gx * gy))
+      , igx(1.0 / gx)
+    {}
 
-    struct alg_inv_pad_x
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        // in: (z, x, y) of (gz, gx, gy*2) complex
-        // out: (z, y, x) of (gz, gy, gx*2) complex
-        karray1d_dev in;
-        karray1d_dev out;
+      int iz = i * igxgy;
+      int iy = (i - iz * gy * gx) * igx;
+      int ix = i - iz * gy * gx - iy * gx;
 
-        int gx, gy;
-        int dgx, dgy;
-        double igxgy;
-        double igy;
+      out(ix * gy * gz + iy * gz + iz) =
+        -in((iz * gy * dgx + iy * dgx + ix) * 2 + 0);
+    }
+  };
 
-        alg_inv_pad_x(
-                karray1d_dev const& in,
-                karray1d_dev const& out,
-                std::array<int, 3> const& g )
-            : in(in), out(out)
-            , gx(g[0]), gy(g[1])
-            , dgx(2*g[0]), dgy(2*g[1])
-            , igxgy(1.0/(gx*gy))
-            , igy(1.0/gy)
-        { }
+  struct alg_shift_forward {
+    karray1d_dev in;
+    int gx;
+    double igx;
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            int iz = i * igxgy;
-            int ix = (i - iz*gx*gy) * igy;
-            int iy = i - iz*gx*gy - ix*gy;
+    alg_shift_forward(karray1d_dev const& in, int gx)
+      : in(in), gx(gx), igx(1.0 / gx)
+    {}
 
-            // { 1, 2, 3 } -> 
-            // { 0, 0, 0, 1, 0, 2, 0, 3, 0, 2, 0, 1 }
-            int out_idx = iz*gy*dgx + iy*dgx + ix+1;
-            int  in_idx = iz*gx*dgy + ix*dgy + iy;
-
-            out(out_idx*2 + 0) = 0.0;
-            out(out_idx*2 + 1) = -in(in_idx*2 + 0);
-
-            // mirror
-            out_idx = (ix == gx - 1) 
-                ? (iz*gy*dgx + iy*dgx + 0)
-                : (iz*gy*dgx + iy*dgx + dgx-1-ix);
-
-            out(out_idx*2 + 0) = 0.0;
-            out(out_idx*2 + 1) = -in(in_idx*2 + 0);
-        }
-    };
-
-    struct alg_inv_pad_z
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        // in: (z, y, x) of (gz, gy, gx*2) complex
-        // out: (x, y, z) of (gx, gy, gz) double
-        karray1d_dev in;
-        karray1d_dev out;
+      const int idx = i * igx;
+      const int ix = i - idx * gx;
 
-        int gx, gy, gz;
-        int dgx;
-        double igxgy;
-        double igx;
+      double dk = (ix + 1) * mconstants::pi * igx * 0.5;
 
-        alg_inv_pad_z(
-                karray1d_dev const& in,
-                karray1d_dev const& out,
-                std::array<int, 3> const& g )
-            : in(in), out(out)
-            , gx(g[0]), gy(g[1]), gz(g[2])
-            , dgx(g[0]*2)
-            , igxgy(1.0/(gx*gy))
-            , igx(1.0/gx)
-        { }
+      double imag = -in(idx * gx * 4 + (ix + 1) * 2 + 0) * sin(dk) +
+                    in(idx * gx * 4 + (ix + 1) * 2 + 1) * cos(dk);
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            int iz = i * igxgy;
-            int iy = (i - iz*gy*gx) * igx;
-            int ix = i - iz*gy*gx - iy*gx;
+      in(idx * gx * 4 + (ix + 1) * 2 + 1) = imag;
+    }
+  };
 
-            out(ix*gy*gz + iy*gz + iz)
-                = -in((iz*gy*dgx + iy*dgx + ix)*2 + 0);
-        }
-    };
+  struct alg_shift_backward {
+    karray1d_dev in;
+    int gx;
+    double igx;
 
+    alg_shift_backward(karray1d_dev const& in, int gx)
+      : in(in), gx(gx), igx(1.0 / gx)
+    {}
 
-    struct alg_shift_forward
+    KOKKOS_INLINE_FUNCTION
+    void
+    operator()(const int i) const
     {
-        karray1d_dev in;
-        int gx;
-        double igx;
+      const int idx = i * igx;
+      const int ix = i - idx * gx;
 
-        alg_shift_forward(karray1d_dev const& in, int gx)
-            : in(in), gx(gx), igx(1.0/gx)
-        { }
+      double dk = ix * mconstants::pi * igx;
 
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            const int idx = i * igx;
-            const int ix = i - idx*gx;
+      double real = in((idx * gx + ix) * 2 + 0) * cos(dk) -
+                    in((idx * gx + ix) * 2 + 1) * sin(dk);
 
-            double dk = (ix+1) * mconstants::pi * igx * 0.5;
+      double imag = in((idx * gx + ix) * 2 + 0) * sin(dk) +
+                    in((idx * gx + ix) * 2 + 1) * cos(dk);
 
-            double imag = 
-                - in(idx*gx*4 + (ix+1)*2 + 0) * sin(dk)
-                + in(idx*gx*4 + (ix+1)*2 + 1) * cos(dk);
-
-            in(idx*gx*4 + (ix+1)*2 + 1) = imag;
-        }
-    };
-
-    struct alg_shift_backward
-    {
-        karray1d_dev in;
-        int gx;
-        double igx;
-
-        alg_shift_backward(karray1d_dev const& in, int gx)
-            : in(in), gx(gx), igx(1.0/gx)
-        { }
-
-        KOKKOS_INLINE_FUNCTION
-        void operator() (const int i) const
-        {
-            const int idx = i * igx;
-            const int ix = i - idx*gx;
-
-            double dk = ix * mconstants::pi * igx;
-
-            double real = in((idx*gx + ix)*2 + 0) * cos(dk)
-                        - in((idx*gx + ix)*2 + 1) * sin(dk);
-
-            double imag = in((idx*gx + ix)*2 + 0) * sin(dk)
-                        + in((idx*gx + ix)*2 + 1) * cos(dk);
-
-            in((idx*gx + ix)*2 + 0) = real;
-            in((idx*gx + ix)*2 + 1) = imag;
-        }
-    };
+      in((idx * gx + ix) * 2 + 0) = real;
+      in((idx * gx + ix) * 2 + 1) = imag;
+    }
+  };
 }
 
 Distributed_fft3d_rect::Distributed_fft3d_rect()
-    : Distributed_fft3d_rect_base()
-    , data1()
-    , data2()
-    , plan_x()
-    , plan_y()
-    , plan_z()
-    , inv_plan_x()
-    , inv_plan_y()
-    , inv_plan_z()
+  : Distributed_fft3d_rect_base()
+  , data1()
+  , data2()
+  , plan_x()
+  , plan_y()
+  , plan_z()
+  , inv_plan_x()
+  , inv_plan_y()
+  , inv_plan_z()
+{}
+
+void
+Distributed_fft3d_rect::construct(std::array<int, 3> const& new_shape,
+                                  Commxx const& new_comm)
 {
-}
+  cufftDestroy(plan_x);
+  cufftDestroy(plan_y);
+  cufftDestroy(plan_z);
 
-void Distributed_fft3d_rect::construct(
-        std::array<int, 3> const & new_shape, 
-        Commxx const& new_comm)
-{
-    cufftDestroy(plan_x);
-    cufftDestroy(plan_y);
-    cufftDestroy(plan_z);
+  cufftDestroy(inv_plan_x);
+  cufftDestroy(inv_plan_y);
+  cufftDestroy(inv_plan_z);
 
-    cufftDestroy(inv_plan_x);
-    cufftDestroy(inv_plan_y);
-    cufftDestroy(inv_plan_z);
+  if (new_comm.is_null()) return;
 
-    if (new_comm.is_null())
-        return;
+  if (new_comm.size() > new_shape[0]) {
+    throw std::runtime_error(
+      "Distributed_fft3d_rect: (number of processors) must be "
+      "<= shape[0]");
+  }
 
-    if (new_comm.size() > new_shape[0]) 
-    {
-        throw std::runtime_error( 
-                "Distributed_fft3d_rect: (number of processors) must be "
-                "<= shape[0]");
-    }
+  shape = new_shape;
+  comm = new_comm;
 
-    shape = new_shape;
-    comm = new_comm;
+  lower = 0;
+  nx = shape[0];
 
-    lower = 0;
-    nx = shape[0];
+  // (x*2, y, z) of a complex grid for batched DST along x
+  // (x, y*2, z) of a complex grid for batched DST along y
+  data1 = karray1d_dev("data1", shape[0] * 4 * shape[1] * shape[2]);
+  data2 = karray1d_dev("data2", shape[0] * shape[1] * 4 * shape[2]);
 
-    // (x*2, y, z) of a complex grid for batched DST along x
-    // (x, y*2, z) of a complex grid for batched DST along y
-    data1 = karray1d_dev("data1", shape[0]*4*shape[1]*shape[2]);
-    data2 = karray1d_dev("data2", shape[0]*shape[1]*4*shape[2]);
+  int rank = 1;
+  int istride = 1;
+  int ostride = 1;
 
-    int rank = 1;
-    int istride = 1;
-    int ostride = 1;
+  // plan x
+  int n_x[] = {shape[0] * 2};
+  int inembed_x[] = {shape[0] * 2};
+  int onembed_x[] = {shape[0] * 2};
+  int idist_x = shape[0] * 2;
+  int odist_x = shape[0] * 2;
 
-    // plan x
-    int n_x[] = {shape[0]*2};
-    int inembed_x[] = {shape[0]*2};
-    int onembed_x[] = {shape[0]*2};
-    int idist_x = shape[0]*2;
-    int odist_x = shape[0]*2;
+  cufftPlanMany(&plan_x,
+                rank,
+                n_x,
+                inembed_x,
+                istride,
+                idist_x,
+                onembed_x,
+                ostride,
+                odist_x,
+                CUFFT_Z2Z,
+                shape[1] * shape[2]);
 
-    cufftPlanMany(&plan_x, rank, n_x,
-            inembed_x, istride, idist_x,
-            onembed_x, ostride, odist_x,
-            CUFFT_Z2Z, shape[1]*shape[2]);
+  cufftPlanMany(&inv_plan_x,
+                rank,
+                n_x,
+                onembed_x,
+                ostride,
+                odist_x,
+                inembed_x,
+                istride,
+                idist_x,
+                CUFFT_Z2Z,
+                shape[1] * shape[2]);
 
-    cufftPlanMany(&inv_plan_x, rank, n_x,
-            onembed_x, ostride, odist_x,
-            inembed_x, istride, idist_x,
-            CUFFT_Z2Z, shape[1]*shape[2]);
+  // plan y
+  int n_y[] = {shape[1] * 2};
+  int inembed_y[] = {shape[1] * 2};
+  int onembed_y[] = {shape[1] * 2};
+  int idist_y = shape[1] * 2;
+  int odist_y = shape[1] * 2;
 
-    // plan y
-    int n_y[] = {shape[1]*2};
-    int inembed_y[] = {shape[1]*2};
-    int onembed_y[] = {shape[1]*2};
-    int idist_y = shape[1]*2;
-    int odist_y = shape[1]*2;
+  cufftPlanMany(&plan_y,
+                rank,
+                n_y,
+                inembed_y,
+                istride,
+                idist_y,
+                onembed_y,
+                ostride,
+                odist_y,
+                CUFFT_Z2Z,
+                shape[0] * shape[2]);
 
-    cufftPlanMany(&plan_y, rank, n_y,
-            inembed_y, istride, idist_y,
-            onembed_y, ostride, odist_y,
-            CUFFT_Z2Z, shape[0]*shape[2]);
+  cufftPlanMany(&inv_plan_y,
+                rank,
+                n_y,
+                onembed_y,
+                ostride,
+                odist_y,
+                inembed_y,
+                istride,
+                idist_y,
+                CUFFT_Z2Z,
+                shape[0] * shape[2]);
 
-    cufftPlanMany(&inv_plan_y, rank, n_y,
-            onembed_y, ostride, odist_y,
-            inembed_y, istride, idist_y,
-            CUFFT_Z2Z, shape[0]*shape[2]);
+  // plan z
+  int n_z[] = {shape[2]};
+  int inembed_z[] = {shape[2]};
+  int onembed_z[] = {shape[2]};
+  int idist_z = shape[2];
+  int odist_z = shape[2] / 2 + 1;
 
-    // plan z
-    int n_z[] = {shape[2]};
-    int inembed_z[] = {shape[2]};
-    int onembed_z[] = {shape[2]};
-    int idist_z = shape[2];
-    int odist_z = shape[2]/2+1;
+  cufftPlanMany(&plan_z,
+                rank,
+                n_z,
+                inembed_z,
+                istride,
+                idist_z,
+                onembed_z,
+                ostride,
+                odist_z,
+                CUFFT_D2Z,
+                shape[0] * shape[1]);
 
-    cufftPlanMany(&plan_z, rank, n_z,
-            inembed_z, istride, idist_z,
-            onembed_z, ostride, odist_z,
-            CUFFT_D2Z, shape[0]*shape[1]);
-
-    cufftPlanMany(&inv_plan_z, rank, n_z,
-            onembed_z, ostride, odist_z,
-            inembed_z, istride, idist_z,
-            CUFFT_Z2D, shape[0]*shape[1]);
+  cufftPlanMany(&inv_plan_z,
+                rank,
+                n_z,
+                onembed_z,
+                ostride,
+                odist_z,
+                inembed_z,
+                istride,
+                idist_z,
+                CUFFT_Z2D,
+                shape[0] * shape[1]);
 }
 
 void
 Distributed_fft3d_rect::transform(karray1d_dev& in, karray1d_dev& out)
 {
-    const int gx = shape[0];
-    const int gy = shape[1];
-    const int gz = shape[2];
+  const int gx = shape[0];
+  const int gy = shape[1];
+  const int gz = shape[2];
 
-    zero(data1);
-    zero(data2);
+  zero(data1);
+  zero(data2);
 
-    // pad x
-    alg_pad_x padx(in, data1, shape);
-    Kokkos::parallel_for(gx*gy*gz, padx);
+  // pad x
+  alg_pad_x padx(in, data1, shape);
+  Kokkos::parallel_for(gx * gy * gz, padx);
 
-    // dft x
-    auto res = cufftExecZ2Z(plan_x,
-            (cufftDoubleComplex*)data1.data(),
-            (cufftDoubleComplex*)data1.data(),
-            CUFFT_FORWARD);
+  // dft x
+  auto res = cufftExecZ2Z(plan_x,
+                          (cufftDoubleComplex*)data1.data(),
+                          (cufftDoubleComplex*)data1.data(),
+                          CUFFT_FORWARD);
 
-    // shift x
-    alg_shift_forward shiftx(data1, gx);
-    Kokkos::parallel_for(gx*gy*gz, shiftx);
+  // shift x
+  alg_shift_forward shiftx(data1, gx);
+  Kokkos::parallel_for(gx * gy * gz, shiftx);
 
-    // pad y
-    alg_pad_y pady(data1, data2, shape);
-    Kokkos::parallel_for(gx*gy*gz, pady);
+  // pad y
+  alg_pad_y pady(data1, data2, shape);
+  Kokkos::parallel_for(gx * gy * gz, pady);
 
-    // dft y
-    res = cufftExecZ2Z(plan_y,
-            (cufftDoubleComplex*)data2.data(),
-            (cufftDoubleComplex*)data2.data(),
-            CUFFT_FORWARD);
+  // dft y
+  res = cufftExecZ2Z(plan_y,
+                     (cufftDoubleComplex*)data2.data(),
+                     (cufftDoubleComplex*)data2.data(),
+                     CUFFT_FORWARD);
 
-    // shift y
-    alg_shift_forward shifty(data2, gy);
-    Kokkos::parallel_for(gx*gy*gz, shifty);
+  // shift y
+  alg_shift_forward shifty(data2, gy);
+  Kokkos::parallel_for(gx * gy * gz, shifty);
 
-    // pad z
-    alg_pad_z padz(data2, data1, shape);
-    Kokkos::parallel_for(gx*gy*gz, padz);
+  // pad z
+  alg_pad_z padz(data2, data1, shape);
+  Kokkos::parallel_for(gx * gy * gz, padz);
 
-    // dft z
-    res = cufftExecD2Z(plan_z,
-            (cufftDoubleReal*)data1.data(),
-            (cufftDoubleComplex*)out.data() );
+  // dft z
+  res = cufftExecD2Z(
+    plan_z, (cufftDoubleReal*)data1.data(), (cufftDoubleComplex*)out.data());
 }
 
 void
 Distributed_fft3d_rect::inv_transform(karray1d_dev& in, karray1d_dev& out)
 {
-    const int gx = shape[0];
-    const int gy = shape[1];
-    const int gz = shape[2];
+  const int gx = shape[0];
+  const int gy = shape[1];
+  const int gz = shape[2];
 
-    // dft z
-    auto res = cufftExecZ2D(inv_plan_z,
-            (cufftDoubleComplex*)in.data(),
-            (cufftDoubleReal*)data1.data() );
+  // dft z
+  auto res = cufftExecZ2D(
+    inv_plan_z, (cufftDoubleComplex*)in.data(), (cufftDoubleReal*)data1.data());
 
-    // pady
-    alg_inv_pad_y pady(data1, data2, shape);
-    Kokkos::parallel_for(gx*gy*gz, pady);
+  // pady
+  alg_inv_pad_y pady(data1, data2, shape);
+  Kokkos::parallel_for(gx * gy * gz, pady);
 
-    // shifty
-    alg_shift_backward shifty(data2, gy*2);
-    Kokkos::parallel_for(gx*gy*gz*2, shifty);
+  // shifty
+  alg_shift_backward shifty(data2, gy * 2);
+  Kokkos::parallel_for(gx * gy * gz * 2, shifty);
 
-    // z2z along y
-    res = cufftExecZ2Z(inv_plan_y,
-            (cufftDoubleComplex*)data2.data(),
-            (cufftDoubleComplex*)data2.data(),
-            CUFFT_INVERSE);
+  // z2z along y
+  res = cufftExecZ2Z(inv_plan_y,
+                     (cufftDoubleComplex*)data2.data(),
+                     (cufftDoubleComplex*)data2.data(),
+                     CUFFT_INVERSE);
 
-    // padx
-    alg_inv_pad_x padx(data2, data1, shape);
-    Kokkos::parallel_for(gx*gy*gz, padx);
+  // padx
+  alg_inv_pad_x padx(data2, data1, shape);
+  Kokkos::parallel_for(gx * gy * gz, padx);
 
-    // shiftx
-    alg_shift_backward shiftx(data1, gx*2);
-    Kokkos::parallel_for(gx*gy*gz*2, shiftx);
+  // shiftx
+  alg_shift_backward shiftx(data1, gx * 2);
+  Kokkos::parallel_for(gx * gy * gz * 2, shiftx);
 
-    // z2z along x
-    res = cufftExecZ2Z(inv_plan_x,
-            (cufftDoubleComplex*)data1.data(),
-            (cufftDoubleComplex*)data1.data(),
-            CUFFT_INVERSE);
+  // z2z along x
+  res = cufftExecZ2Z(inv_plan_x,
+                     (cufftDoubleComplex*)data1.data(),
+                     (cufftDoubleComplex*)data1.data(),
+                     CUFFT_INVERSE);
 
-    // re-arrange for final array
-    alg_inv_pad_z padz(data1, out, shape);
-    Kokkos::parallel_for(gx*gy*gz, padz);
+  // re-arrange for final array
+  alg_inv_pad_z padz(data1, out, shape);
+  Kokkos::parallel_for(gx * gy * gz, padz);
 }
 
 Distributed_fft3d_rect::~Distributed_fft3d_rect()
 {
-    cufftDestroy(plan_x);
-    cufftDestroy(plan_y);
-    cufftDestroy(plan_z);
+  cufftDestroy(plan_x);
+  cufftDestroy(plan_y);
+  cufftDestroy(plan_z);
 
-    cufftDestroy(inv_plan_x);
-    cufftDestroy(inv_plan_y);
-    cufftDestroy(inv_plan_z);
+  cufftDestroy(inv_plan_x);
+  cufftDestroy(inv_plan_y);
+  cufftDestroy(inv_plan_z);
 }
-

--- a/src/synergia/utils/multi_array_typedefs.h
+++ b/src/synergia/utils/multi_array_typedefs.h
@@ -4,177 +4,153 @@
 #include <Kokkos_Core.hpp>
 
 // column major, non-const arrays
-typedef Kokkos::View<double*,   Kokkos::LayoutLeft> karray1d_dev;
-typedef Kokkos::View<double**,  Kokkos::LayoutLeft> karray2d_dev;
-typedef Kokkos::View<double***, Kokkos::LayoutLeft> karray3d_dev;
+typedef Kokkos::View<double *, Kokkos::LayoutLeft,
+                     Kokkos::DefaultExecutionSpace>
+    karray1d_dev;
+typedef Kokkos::View<double **, Kokkos::LayoutLeft,
+                     Kokkos::DefaultExecutionSpace>
+    karray2d_dev;
+typedef Kokkos::View<double ***, Kokkos::LayoutLeft,
+                     Kokkos::DefaultExecutionSpace>
+    karray3d_dev;
 
 typedef karray1d_dev::HostMirror karray1d_hst;
 typedef karray2d_dev::HostMirror karray2d_hst;
 typedef karray3d_dev::HostMirror karray3d_hst;
 
-typedef karray1d_hst karray1d;
-typedef karray2d_hst karray2d;
-typedef karray3d_hst karray3d;
-
+typedef Kokkos::View<double *, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray1d;
+typedef Kokkos::View<double **, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray2d;
+typedef Kokkos::View<double ***, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray3d;
 
 // column major, const arrays
-typedef Kokkos::View<const double*,   Kokkos::LayoutLeft> const_karray1d_dev;
-typedef Kokkos::View<const double**,  Kokkos::LayoutLeft> const_karray2d_dev;
-typedef Kokkos::View<const double***, Kokkos::LayoutLeft> const_karray3d_dev;
+typedef Kokkos::View<const double *, Kokkos::LayoutLeft,
+                     Kokkos::DefaultExecutionSpace>
+    const_karray1d_dev;
+typedef Kokkos::View<const double **, Kokkos::LayoutLeft,
+                     Kokkos::DefaultExecutionSpace>
+    const_karray2d_dev;
+typedef Kokkos::View<const double ***, Kokkos::LayoutLeft,
+                     Kokkos::DefaultExecutionSpace>
+    const_karray3d_dev;
 
 typedef const_karray1d_dev::HostMirror const_karray1d_hst;
 typedef const_karray2d_dev::HostMirror const_karray2d_hst;
 typedef const_karray3d_dev::HostMirror const_karray3d_hst;
 
-typedef const_karray1d_hst const_karray1d;
-typedef const_karray2d_hst const_karray2d;
-typedef const_karray3d_hst const_karray3d;
-
+typedef Kokkos::View<const double *, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    const_karray1d;
+typedef Kokkos::View<const double **, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    const_karray2d;
+typedef Kokkos::View<const double ***, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    const_karray3d;
 
 // row major, non-const arrays
-typedef Kokkos::View<double*,   Kokkos::LayoutRight> karray1d_row_dev;
-typedef Kokkos::View<double**,  Kokkos::LayoutRight> karray2d_row_dev;
-typedef Kokkos::View<double***, Kokkos::LayoutRight> karray3d_row_dev;
+typedef Kokkos::View<double *, Kokkos::LayoutRight,
+                     Kokkos::DefaultExecutionSpace>
+    karray1d_row_dev;
+typedef Kokkos::View<double **, Kokkos::LayoutRight,
+                     Kokkos::DefaultExecutionSpace>
+    karray2d_row_dev;
+typedef Kokkos::View<double ***, Kokkos::LayoutRight,
+                     Kokkos::DefaultExecutionSpace>
+    karray3d_row_dev;
 
 typedef karray1d_row_dev::HostMirror karray1d_row_hst;
 typedef karray2d_row_dev::HostMirror karray2d_row_hst;
 typedef karray3d_row_dev::HostMirror karray3d_row_hst;
 
-typedef karray1d_row_hst karray1d_row;
-typedef karray2d_row_hst karray2d_row;
-typedef karray3d_row_hst karray3d_row;
-
+typedef Kokkos::View<double *, Kokkos::LayoutRight,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray1d_row;
+typedef Kokkos::View<double **, Kokkos::LayoutRight,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray2d_row;
+typedef Kokkos::View<double ***, Kokkos::LayoutRight,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray3d_row;
 
 // row major, const arrays
-typedef Kokkos::View<const double*,   Kokkos::LayoutRight> const_karray1d_row_dev;
-typedef Kokkos::View<const double**,  Kokkos::LayoutRight> const_karray2d_row_dev;
-typedef Kokkos::View<const double***, Kokkos::LayoutRight> const_karray3d_row_dev;
+typedef Kokkos::View<const double *, Kokkos::LayoutRight>
+    const_karray1d_row_dev;
+typedef Kokkos::View<const double **, Kokkos::LayoutRight>
+    const_karray2d_row_dev;
+typedef Kokkos::View<const double ***, Kokkos::LayoutRight>
+    const_karray3d_row_dev;
 
 typedef const_karray1d_row_dev::HostMirror const_karray1d_row_hst;
 typedef const_karray2d_row_dev::HostMirror const_karray2d_row_hst;
 typedef const_karray3d_row_dev::HostMirror const_karray3d_row_hst;
 
-typedef const_karray1d_row_hst const_karray1d_row;
-typedef const_karray2d_row_hst const_karray2d_row;
-typedef const_karray3d_row_hst const_karray3d_row;
-
+typedef Kokkos::View<const double *, Kokkos::LayoutRight,
+                     Kokkos::DefaultHostExecutionSpace>
+    const_karray1d_row;
+typedef Kokkos::View<const double **, Kokkos::LayoutRight,
+                     Kokkos::DefaultHostExecutionSpace>
+    const_karray2d_row;
+typedef Kokkos::View<const double ***, Kokkos::LayoutRight,
+                     Kokkos::DefaultHostExecutionSpace>
+    const_karray3d_row;
 
 // row major, non-const int arrays
-typedef Kokkos::View<int*,   Kokkos::LayoutRight> karray1i_row_dev;
-typedef Kokkos::View<int**,  Kokkos::LayoutRight> karray2i_row_dev;
-typedef Kokkos::View<int***, Kokkos::LayoutRight> karray3i_row_dev;
+typedef Kokkos::View<int *, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace>
+    karray1i_row_dev;
+typedef Kokkos::View<int **, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace>
+    karray2i_row_dev;
+typedef Kokkos::View<int ***, Kokkos::LayoutRight,
+                     Kokkos::DefaultExecutionSpace>
+    karray3i_row_dev;
 
 typedef karray1i_row_dev::HostMirror karray1i_row_hst;
 typedef karray2i_row_dev::HostMirror karray2i_row_hst;
 typedef karray3i_row_dev::HostMirror karray3i_row_hst;
 
-typedef karray1i_row_hst karray1i_row;
-typedef karray2i_row_hst karray2i_row;
-typedef karray3i_row_hst karray3i_row;
-
+typedef Kokkos::View<int *, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray1i_row;
+typedef Kokkos::View<int **, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray2i_row;
+typedef Kokkos::View<int ***, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray3i_row;
 
 // row major, non-const complex arrays
-typedef Kokkos::View<Kokkos::complex<double>*,   Kokkos::LayoutRight> karray1dc_row_dev;
-typedef Kokkos::View<Kokkos::complex<double>**,  Kokkos::LayoutRight> karray2dc_row_dev;
-typedef Kokkos::View<Kokkos::complex<double>***, Kokkos::LayoutRight> karray3dc_row_dev;
+typedef Kokkos::View<Kokkos::complex<double> *, Kokkos::LayoutRight,
+                     Kokkos::DefaultExecutionSpace>
+    karray1dc_row_dev;
+typedef Kokkos::View<Kokkos::complex<double> **, Kokkos::LayoutRight,
+                     Kokkos::DefaultExecutionSpace>
+    karray2dc_row_dev;
+typedef Kokkos::View<Kokkos::complex<double> ***, Kokkos::LayoutRight,
+                     Kokkos::DefaultExecutionSpace>
+    karray3dc_row_dev;
 
 typedef karray1dc_row_dev::HostMirror karray1dc_row_hst;
 typedef karray2dc_row_dev::HostMirror karray2dc_row_hst;
 typedef karray3dc_row_dev::HostMirror karray3dc_row_hst;
 
-typedef karray1dc_row_hst karray1dc_row;
-typedef karray2dc_row_hst karray2dc_row;
-typedef karray3dc_row_hst karray3dc_row;
-
+typedef Kokkos::View<Kokkos::complex<double> *, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray1dc_row;
+typedef Kokkos::View<Kokkos::complex<double> **, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray2dc_row;
+typedef Kokkos::View<Kokkos::complex<double> ***, Kokkos::LayoutLeft,
+                     Kokkos::DefaultHostExecutionSpace>
+    karray3dc_row;
 
 // atomic arrays
-typedef Kokkos::View< double*, 
-                      Kokkos::LayoutLeft, 
-                      Kokkos::MemoryTraits<Kokkos::Atomic> > karray1d_atomic_dev;
-
-
-#if 0
-#include "boost/multi_array.hpp"
-#include "boost/shared_array.hpp"
-
-//#include "boost/align/aligned_allocator.hpp"
-
-typedef boost::multi_array_types::index_range range;
-typedef boost::multi_array_types::extent_range extent_range;
-
-template<typename T, size_t N_dims>
-    struct Raw_multi_array
-    {
-        boost::const_multi_array_ref<T, N_dims > * dummy;
-        typedef typename boost::const_multi_array_ref<T, N_dims >::storage_order_type storage_order_type;
-        boost::shared_array<T > p;
-        boost::multi_array_ref<T, N_dims > m;
-        template<class ExtentList>
-            explicit
-            Raw_multi_array(const ExtentList& extents,
-                    const storage_order_type& store = boost::c_storage_order()) :
-                    dummy(
-                            new boost::const_multi_array_ref<T, N_dims >(
-                                    static_cast<T* >(0L), extents, store)), p(
-                            new T[dummy->num_elements()]), m(p.get(), extents, store)
-            {
-                delete dummy;
-            }
-        ~Raw_multi_array()
-        {
-        }
-    };
-
-typedef boost::multi_array<double, 1 > MArray1d; // syndoc:include
-typedef boost::multi_array_ref<double, 1 > MArray1d_ref; // syndoc:include
-typedef boost::const_multi_array_ref<double, 1 > Const_MArray1d_ref; // syndoc:include
-typedef boost::detail::multi_array::multi_array_view<double, 1 > MArray1d_view;  // syndoc:include
-typedef Raw_multi_array<double, 1> Raw_MArray1d; // syndoc:include
-
-
-typedef boost::multi_array<double, 2 > MArray2d; // syndoc:include
-//typedef boost::multi_array<double, 2, boost::alignment::aligned_allocator<double, 64> > MArray2da; // syndoc:include
-typedef boost::multi_array_ref<double, 2 > MArray2d_ref; // syndoc:include
-typedef boost::const_multi_array_ref<double, 2 > Const_MArray2d_ref; // syndoc:include
-typedef boost::detail::multi_array::multi_array_view<double, 2 > MArray2d_view; // syndoc:include
-typedef boost::detail::multi_array::const_multi_array_view<double, 2 >
-        Const_MArray2d_view; // syndoc:include
-typedef boost::general_storage_order<2> storage2d;
-typedef Raw_multi_array<double, 2> Raw_MArray2d; // syndoc:include
-
-typedef boost::multi_array<double, 3 > MArray3d; // syndoc:include
-typedef boost::multi_array_ref<double, 3 > MArray3d_ref; // syndoc:include
-typedef boost::const_multi_array_ref<double, 3 > Const_MArray3d_ref; // syndoc:include
-typedef boost::detail::multi_array::multi_array_view<double, 3 > MArray3d_view; // syndoc:include
-typedef boost::general_storage_order<3> storage3d;
-typedef Raw_multi_array<double, 3> Raw_MArray3d; // syndoc:include
-
-typedef boost::multi_array<std::complex<double >, 1 > MArray1dc; // syndoc:include
-typedef boost::multi_array_ref<std::complex<double >, 1 > MArray1dc_ref; // syndoc:include
-typedef boost::const_multi_array_ref<std::complex<double >, 1 >
-        Const_MArray1dc_ref; // syndoc:include
-typedef boost::detail::multi_array::multi_array_view<std::complex<double >, 1 >
-        MArray1dc_view; // syndoc:include
-
-typedef boost::multi_array<std::complex<double >, 2 > MArray2dc; // syndoc:include
-typedef boost::multi_array_ref<std::complex<double >, 2 > MArray2dc_ref; // syndoc:include
-typedef boost::const_multi_array_ref<std::complex<double >, 2 >
-        Const_MArray2dc_ref; // syndoc:include
-typedef boost::detail::multi_array::multi_array_view<std::complex<double >, 2 >
-        MArray2dc_view; // syndoc:include
-typedef Raw_multi_array<std::complex<double >, 2> Raw_MArray2dc; // syndoc:include
-
-typedef boost::multi_array<std::complex<double >, 3 > MArray3dc; // syndoc:include
-typedef boost::multi_array_ref<std::complex<double >, 3 > MArray3dc_ref; // syndoc:include
-typedef boost::const_multi_array_ref<std::complex<double >, 3 >
-        Const_MArray3dc_ref; // syndoc:include
-typedef boost::detail::multi_array::multi_array_view<std::complex<double >, 3 >
-        MArray3dc_view; // syndoc:include
-
-typedef boost::multi_array<int, 1 > MArray1i; // syndoc:include
-typedef boost::multi_array_ref<int, 1 > MArray1i_ref; // syndoc:include
-typedef boost::const_multi_array_ref<int, 1 > Const_MArray1i_ref; // syndoc:include
-typedef boost::detail::multi_array::multi_array_view<int, 1 > MArray1i_view; // syndoc:include
-#endif
+typedef Kokkos::View<double *, Kokkos::LayoutLeft,
+                     Kokkos::MemoryTraits<Kokkos::Atomic>>
+    karray1d_atomic_dev;
 
 #endif /* MULTI_ARRAY_TYPEDEFS_H_ */

--- a/src/synergia/utils/tests/test_distributed_fft2d.cc
+++ b/src/synergia/utils/tests/test_distributed_fft2d.cc
@@ -1,9 +1,9 @@
-#include "synergia/utils/catch.hpp"
 #include "synergia/foundation/math_constants.h"
+#include "synergia/utils/catch.hpp"
 #include "synergia/utils/distributed_fft2d.h"
 
-#include <complex>
 #include <cmath>
+#include <complex>
 
 // set DBGPRINT to 1 to print values for tolerance failures
 #define DBGPRINT 1
@@ -20,271 +20,245 @@ const int shape1 = 8;
 
 TEST_CASE("construct")
 {
-    REQUIRE_NOTHROW(Distributed_fft2d());
+  REQUIRE_NOTHROW(Distributed_fft2d());
 }
-
 
 TEST_CASE("methods")
 {
-    // construct the fft2d object
-    Distributed_fft2d fft;
+  // construct the fft2d object
+  Distributed_fft2d fft;
 
-    // construct the communicator so that every rank does
-    // the full calculation, by dividing the world into 
-    // subgroups of size 1
-    auto comm_world = std::make_shared<Commxx>(Commxx::World);
-    auto comm = comm_world->divide(1);
+  // construct the communicator so that every rank does
+  // the full calculation, by dividing the world into
+  // subgroups of size 1
+  auto comm_world = std::make_shared<Commxx>(Commxx::World);
+  auto comm = comm_world->divide(1);
 
-    fft.construct({shape0, shape1}, comm);
+  fft.construct({shape0, shape1}, comm);
 
-    SECTION("roundtrip normalization")
-    {
-        double normalization = fft.get_roundtrip_normalization();
-        CHECK(normalization == 1.0/(shape0*shape1));
-    }
+  SECTION("roundtrip normalization")
+  {
+    double normalization = fft.get_roundtrip_normalization();
+    CHECK(normalization == 1.0 / (shape0 * shape1));
+  }
 
-    SECTION("get shape")
-    {
-        auto s = fft.get_shape();
+  SECTION("get shape")
+  {
+    auto s = fft.get_shape();
 
-        CHECK(s.size() == 2);
-        CHECK(s[0] == shape0);
-        CHECK(s[1] == shape1);
-    }
+    CHECK(s.size() == 2);
+    CHECK(s[0] == shape0);
+    CHECK(s[1] == shape1);
+  }
 
-    SECTION("get comm")
-    {
-        CHECK(fft.get_comm() == comm);
-    }
+  SECTION("get comm")
+  {
+    CHECK(fft.get_comm() == comm);
+  }
 
-    SECTION("get lower")
-    {
-        CHECK(fft.get_lower() == 0);
-        CHECK(fft.get_upper() == shape0);
-    }
+  SECTION("get lower")
+  {
+    CHECK(fft.get_lower() == 0);
+    CHECK(fft.get_upper() == shape0);
+  }
 }
-
 
 const double tolerance = 1.0e-12;
 TEST_CASE("transform_roundtrip")
 {
-    // construct the fft2d object
-    Distributed_fft2d fft;
+  // construct the fft2d object
+  Distributed_fft2d fft;
 
-    // construct the communicator so that every rank does
-    // the full calculation, by dividing the world into 
-    // subgroups of size 1
-    auto comm_world = std::make_shared<Commxx>(Commxx::World);
+  // construct the communicator so that every rank does
+  // the full calculation, by dividing the world into
+  // subgroups of size 1
+  auto comm_world = std::make_shared<Commxx>(Commxx::World);
 
 #ifdef KOKKOS_ENABLE_CUDA
-    int subgroup_size = 1;
+  int subgroup_size = 1;
 #else
-    int subgroup_size = Commxx::world_size();
+  int subgroup_size = Commxx::world_size();
 #endif
 
-    auto comm = comm_world->divide(subgroup_size);
+  auto comm = comm_world->divide(subgroup_size);
 
-    fft.construct({shape0, shape1}, comm);
+  fft.construct({shape0, shape1}, comm);
 
+  karray1d_dev d_src("src", shape0 * shape1 * 2);
+  karray1d_dev d_dst("dest", shape0 * shape1 * 2);
 
-    karray1d_dev d_src("src", shape0*shape1*2);
-    karray1d_dev d_dst("dest", shape0*shape1*2);
+  karray1d orig("orig", shape0 * shape1 * 2);
+  karray1d_hst src = Kokkos::create_mirror_view(d_src);
 
-    karray1d orig("orig", shape0*shape1*2);
-    karray1d src = Kokkos::create_mirror_view(d_src);
+  for (int j = 0; j < shape0; ++j) {
+    for (int k = 0; k < shape1; ++k) {
+      src(j * shape1 * 2 + k * 2 + 0) = 1.1 * k + 10 * j;
+      src(j * shape1 * 2 + k * 2 + 1) = 1.2 * k + 10 * j;
 
-    for(int j=0; j<shape0; ++j)
-    {
-        for(int k=0; k<shape1; ++k)
-        {
-            src(j*shape1*2+k*2+0) = 1.1*k+10*j;
-            src(j*shape1*2+k*2+1) = 1.2*k+10*j;
-
-            orig(j*shape1*2+k*2+0) = 1.1*k+10*j;
-            orig(j*shape1*2+k*2+1) = 1.2*k+10*j;
-        }
+      orig(j * shape1 * 2 + k * 2 + 0) = 1.1 * k + 10 * j;
+      orig(j * shape1 * 2 + k * 2 + 1) = 1.2 * k + 10 * j;
     }
+  }
 
-    Kokkos::deep_copy(d_src, src);
+  Kokkos::deep_copy(d_src, src);
 
-    fft.transform(d_src, d_dst);
-    fft.inv_transform(d_dst, d_src);
+  fft.transform(d_src, d_dst);
+  fft.inv_transform(d_dst, d_src);
 
-    Kokkos::deep_copy(src, d_src);
+  Kokkos::deep_copy(src, d_src);
 
-    auto norm = fft.get_roundtrip_normalization();
-    int lower = fft.get_lower();
-    int upper = fft.get_upper();
+  auto norm = fft.get_roundtrip_normalization();
+  int lower = fft.get_lower();
+  int upper = fft.get_upper();
 
-    for(int j=lower; j<upper; ++j)
-    {
-        for(int k=0; k<shape1; ++k)
-        {
-            int idx_real = j*shape1*2+k*2+0;
-            int idx_imag = j*shape1*2+k*2+1;
+  for (int j = lower; j < upper; ++j) {
+    for (int k = 0; k < shape1; ++k) {
+      int idx_real = j * shape1 * 2 + k * 2 + 0;
+      int idx_imag = j * shape1 * 2 + k * 2 + 1;
 
-            CHECK(src(idx_real)*norm == Approx(orig(idx_real)).margin(tolerance));
-            CHECK(src(idx_imag)*norm == Approx(orig(idx_imag)).margin(tolerance));
-        }
+      CHECK(src(idx_real) * norm == Approx(orig(idx_real)).margin(tolerance));
+      CHECK(src(idx_imag) * norm == Approx(orig(idx_imag)).margin(tolerance));
     }
+  }
 }
 
 TEST_CASE("transform_realtest")
 {
-    // construct the fft2d object
-    Distributed_fft2d fft;
+  // construct the fft2d object
+  Distributed_fft2d fft;
 
-    // construct the communicator so that every rank does
-    // the full calculation, by dividing the world into 
-    // subgroups of size 1
-    auto comm_world = std::make_shared<Commxx>(Commxx::World);
+  // construct the communicator so that every rank does
+  // the full calculation, by dividing the world into
+  // subgroups of size 1
+  auto comm_world = std::make_shared<Commxx>(Commxx::World);
 
 #ifdef KOKKOS_ENABLE_CUDA
-    int subgroup_size = 1;
+  int subgroup_size = 1;
 #else
-    int subgroup_size = Commxx::world_size();
+  int subgroup_size = Commxx::world_size();
 #endif
 
-    auto comm = comm_world->divide(subgroup_size);
+  auto comm = comm_world->divide(subgroup_size);
 
-    fft.construct({shape0, shape1}, comm);
+  fft.construct({shape0, shape1}, comm);
 
-    karray1d_dev d_orig("orig", shape0*shape1*2);
-    karray1d_dev d_dest("dest", shape0*shape1*2);
+  karray1d_dev d_orig("orig", shape0 * shape1 * 2);
+  karray1d_dev d_dest("dest", shape0 * shape1 * 2);
 
-    karray1d orig = Kokkos::create_mirror_view(d_orig);
-    karray1d dest = Kokkos::create_mirror_view(d_dest);
+  karray1d_hst orig = Kokkos::create_mirror_view(d_orig);
+  karray1d_hst dest = Kokkos::create_mirror_view(d_dest);
 
-    int lower = fft.get_lower();
-    int upper = fft.get_upper();
+  int lower = fft.get_lower();
+  int upper = fft.get_upper();
 
-    // the location of the constructed frequency space peak
-    const int loc0 = 7;
-    const int loc1 = 2;
+  // the location of the constructed frequency space peak
+  const int loc0 = 7;
+  const int loc1 = 2;
 
-    // in range
-    REQUIRE(loc0 > 0);
-    REQUIRE(loc0 < shape0);
+  // in range
+  REQUIRE(loc0 > 0);
+  REQUIRE(loc0 < shape0);
 
-    REQUIRE(loc1 > 0);
-    REQUIRE(loc1 < shape1);
+  REQUIRE(loc1 > 0);
+  REQUIRE(loc1 < shape1);
 
-    // The frequency corresponding to the array position
-    const double freq0 = double(loc0)/shape0;
-    const double freq1 = double(loc1)/shape1;
+  // The frequency corresponding to the array position
+  const double freq0 = double(loc0) / shape0;
+  const double freq1 = double(loc1) / shape1;
 
-    const double dx0 = 1.0;
-    const double dx1 = 1.0;
+  const double dx0 = 1.0;
+  const double dx1 = 1.0;
 
-    // fill the input array
-    double x0 = lower * dx0;
+  // fill the input array
+  double x0 = lower * dx0;
 
-    const double pi = mconstants::pi;
-    
-    for (int i0=lower; i0<upper; ++i0) 
-    {
-        if (i0 >= shape0/2) x0 -= shape0*dx0;
+  const double pi = mconstants::pi;
 
-        double x1 = 0.0; 
+  for (int i0 = lower; i0 < upper; ++i0) {
+    if (i0 >= shape0 / 2) x0 -= shape0 * dx0;
 
-        for (int i1=0; i1<shape1; ++i1) 
-        { 
-            if (i1 >= shape1/2) x1 -= shape1*dx1;
+    double x1 = 0.0;
 
-            // will with exp(2*pi*i*freq0*x0)*exp(2*pi*i*freq1*x1) which is
-            // a delta function in frequency space
-            double real = (cos(2.0*pi*freq0*x0)*cos(2.0*pi*freq1*x1) 
-                    - sin(2.0*pi*freq0*x0)*sin(2.0*pi*freq1*x1));
+    for (int i1 = 0; i1 < shape1; ++i1) {
+      if (i1 >= shape1 / 2) x1 -= shape1 * dx1;
 
-            double imag = (sin(2.0*pi*freq0*x0)*cos(2.0*pi*freq1*x1) 
-                    + cos(2.0*pi*freq0*x0)*sin(2.0*pi*freq1*x1));
+      // will with exp(2*pi*i*freq0*x0)*exp(2*pi*i*freq1*x1) which is
+      // a delta function in frequency space
+      double real = (cos(2.0 * pi * freq0 * x0) * cos(2.0 * pi * freq1 * x1) -
+                     sin(2.0 * pi * freq0 * x0) * sin(2.0 * pi * freq1 * x1));
 
-            orig(i0*shape1*2+i1*2+0) = real;
-            orig(i0*shape1*2+i1*2+1) = imag;
+      double imag = (sin(2.0 * pi * freq0 * x0) * cos(2.0 * pi * freq1 * x1) +
+                     cos(2.0 * pi * freq0 * x0) * sin(2.0 * pi * freq1 * x1));
+
+      orig(i0 * shape1 * 2 + i1 * 2 + 0) = real;
+      orig(i0 * shape1 * 2 + i1 * 2 + 1) = imag;
 
 #if FAILME
-            orig(i0*shape1*2+i1*2+0) *= 1.1;
-            orig(i0*shape1*2+i1*2+1) *= 1.1;
+      orig(i0 * shape1 * 2 + i1 * 2 + 0) *= 1.1;
+      orig(i0 * shape1 * 2 + i1 * 2 + 1) *= 1.1;
 #endif
 
-            x1 += dx1; 
-        } 
-
-        x0 += dx0;
+      x1 += dx1;
     }
 
-    // copy orig to device
-    Kokkos::deep_copy(d_orig, orig);
+    x0 += dx0;
+  }
 
-    // transform
-    fft.transform(d_orig, d_dest);
+  // copy orig to device
+  Kokkos::deep_copy(d_orig, orig);
 
-    // and copy the dest back to host
-    Kokkos::deep_copy(dest, d_dest);
+  // transform
+  fft.transform(d_orig, d_dest);
 
-    // now verify the results
-    double norm = double(shape0 * shape1);
+  // and copy the dest back to host
+  Kokkos::deep_copy(dest, d_dest);
 
-    // I see deviations of a few *1e12
-    double fft_tolerance = 1.0e-11;
+  // now verify the results
+  double norm = double(shape0 * shape1);
 
-    // All the numbers in the result should have a negligible complex part
-    for (int i0=lower; i0<upper; ++i0) 
-    { 
-        for (int i1=0; i1<shape1; ++i1) 
-        { 
-            double imag = dest(i0*shape1*2 + i1*2 + 1);
-            CHECK(std::abs(imag) < fft_tolerance);
+  // I see deviations of a few *1e12
+  double fft_tolerance = 1.0e-11;
+
+  // All the numbers in the result should have a negligible complex part
+  for (int i0 = lower; i0 < upper; ++i0) {
+    for (int i1 = 0; i1 < shape1; ++i1) {
+      double imag = dest(i0 * shape1 * 2 + i1 * 2 + 1);
+      CHECK(std::abs(imag) < fft_tolerance);
 
 #if DBGPRINT
-            if (std::abs(imag) >= fft_tolerance) 
-            {
-                std::cout 
-                    << "imaginary part non-zero failure at (" 
-                    << i0 << "," << i1 << "): " 
-                    << imag << std::endl; 
-            }
-#endif // DBGPRINT 
-        } 
+      if (std::abs(imag) >= fft_tolerance) {
+        std::cout << "imaginary part non-zero failure at (" << i0 << "," << i1
+                  << "): " << imag << std::endl;
+      }
+#endif // DBGPRINT
     }
+  }
 
-    // check the real parts.  All of them should be negligible except for
-    // the one corresponding to the delta function location.
-    for (int i0=lower; i0<upper; ++i0) 
-    { 
-        for (int i1=0; i1<shape1; ++i1) 
-        { 
-            double real = dest(i0*shape1*2 + i1*2 + 0);
+  // check the real parts.  All of them should be negligible except for
+  // the one corresponding to the delta function location.
+  for (int i0 = lower; i0 < upper; ++i0) {
+    for (int i1 = 0; i1 < shape1; ++i1) {
+      double real = dest(i0 * shape1 * 2 + i1 * 2 + 0);
 
-            if ( i0==loc0 && i1==loc1 ) 
-            { 
-                CHECK(std::abs(real-norm) < fft_tolerance);
+      if (i0 == loc0 && i1 == loc1) {
+        CHECK(std::abs(real - norm) < fft_tolerance);
 
 #if DBGPRINT
-                if (std::abs(real-norm) >= fft_tolerance) 
-                { 
-                    std::cout 
-                        << "real part not correct failure at (" 
-                        << i0 << "," << i1 << "): " 
-                        << real << std::endl; 
-                }
-#endif // DBGPRINT 
-            } 
-            else 
-            { 
-                CHECK(std::abs(real) < fft_tolerance);
+        if (std::abs(real - norm) >= fft_tolerance) {
+          std::cout << "real part not correct failure at (" << i0 << "," << i1
+                    << "): " << real << std::endl;
+        }
+#endif // DBGPRINT
+      } else {
+        CHECK(std::abs(real) < fft_tolerance);
 
 #if DBGPRINT
-                if (std::abs(real) >= fft_tolerance) 
-                { 
-                    std::cout 
-                        << "real part not negligible failure at (" 
-                        << i0 << "," << i1 << "): " 
-                        << real << std::endl; 
-                }
-#endif // DBGPRINT 
-            } 
-        } 
+        if (std::abs(real) >= fft_tolerance) {
+          std::cout << "real part not negligible failure at (" << i0 << ","
+                    << i1 << "): " << real << std::endl;
+        }
+#endif // DBGPRINT
+      }
     }
+  }
 }
-


### PR DESCRIPTION
Throughout the repository, host-mirrors are used as host-only arrays even though they don't mirror a corresponding device array. Clarify the difference explicitly.