### PR TITLE
Remove use of Homebrew system python packages

### DIFF
--- a/.github/workflows/macos-clang.yml
+++ b/.github/workflows/macos-clang.yml
@@ -26,11 +26,11 @@ jobs:
 
     - name: Dependencies
       run: |
-        brew install gsl hdf5 fftw libomp numpy pybind11 ninja
+        brew install gsl hdf5 fftw libomp ninja
         python3 -m venv ${{github.workspace}}/synergia-env
         source ${{github.workspace}}/synergia-env/bin/activate
         python3 -m pip install --upgrade pip setuptools wheel
-        python3 -m pip install  pytest pyparsing matplotlib cython mpi4py
+        python3 -m pip install cython matplotlib mpi4py numpy pyparsing pytest
         # We do not install h5py because the pip-installed version may not use
         # a version of HDF5 that matches what we have from Homebrew. Instead,
         # we build our own from source.

--- a/.github/workflows/macos-gcc.yml
+++ b/.github/workflows/macos-gcc.yml
@@ -26,11 +26,11 @@ jobs:
 
     - name: Dependencies
       run: |
-        brew install gcc gsl hdf5 fftw libomp numpy pybind11 ninja
-        python3 -m venv --system-site-packages ${{github.workspace}}/synergia-env
+        brew install gcc gsl hdf5 fftw libomp ninja
+        python3 -m venv ${{github.workspace}}/synergia-env
         source ${{github.workspace}}/synergia-env/bin/activate
         python3 -m pip install --upgrade pip setuptools wheel
-        python3 -m pip install pytest pyparsing matplotlib cython mpi4py
+        python3 -m pip install cython matplotlib mpi4py numpy pyparsing pytest
         # We do not install h5py because the pip-installed version may not use
         # a version of HDF5 that matches what we have from Homebrew. Instead,
         # we build our own from source.

--- a/wiki/build.md
+++ b/wiki/build.md
@@ -137,14 +137,13 @@ See [https://brew.sh](https://brew.sh) for instructions on the installation and 
 
     # Note that the Homebrew installation of hdf5 does not (at the time of this writing)
     # support MPI parallelism.
-    # We install the gcc product to obtain gfortran; see below regarding the use of g++.
-    brew install gcc hdf5 fftw3 libomp numpy mpi4py pybind11
+    brew install gsl hdf5 fftw libomp ninja
 
     # We recommend a python virtual environment for managing module versions.
-    python3 -m venv --system-site-packages synergia-env
+    python3 -m venv synergia-env
     source synergia-env/bin/activate
     python3 -m pip install --upgrade pip
-    python3 -m pip install pytest pyparsing matplotlib cython
+    python3 -m pip install cython matplotlib mpi4py numpy pyparsing pytest
 
     # We do not install h5py using pip because the pip-installed version may not
     # not use a version of HDF5 that matches what we have from the package manager.


### PR DESCRIPTION
This removes uses of `--system-site-packages` from the Python virtual environment and moves several Python packages from installation using Homebrew to installation into the virtual environment.

We still get Python3 itself from Homebrew.