### PR TITLE
add useful github information to project wiki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ install/**
 # clangd LSP files
 compile_commands.json
 **.cache/clangd
+
+# created by vscode editor
+.vscode
+

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@
 
 Please see [this page](wiki/build.md) for build instructions
 
+## Useful Github stuff
+
+Please see [this page](wiki/useful-github-stuff.md) for use Github features used in the project
+
 ## Writing a Synergia Simulation
 
 Here is a simple example to give an idea of how to compose a simulation with Synergia3.

--- a/wiki/useful-github-stuff.md
+++ b/wiki/useful-github-stuff.md
@@ -1,0 +1,7 @@
+# Useful Github Stuff
+
+## Debugging CI workflows
+
+## Checking workflow action `yml` files
+
+Static [github action syntax checker](https://rhysd.github.io/actionlint)


### PR DESCRIPTION
We plan to start putting useful information on how the project uses Github
tools in the wiki starting with how to debug CI workflows.
