### PR TITLE
Gpu build wc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ endif()
 
 project(SYNERGIA2 LANGUAGES CXX C)
 
+
+if(${CMAKE_VERSION} VERSION_GREATER "3.22.0")
+    cmake_policy(SET CMP0127 OLD) # remove this when we move to CMake 3.22
+endif()
+
+
 # generate compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # and place it in the source directory https://stackoverflow.com/a/60910583
@@ -170,6 +176,9 @@ endif()
 if(${MPIEXEC_EXECUTABLE} MATCHES "srun")
   set(MPIEXEC_EXECUTABLE ${MPIEXEC_EXECUTABLE} "--mpi=${SRUN_MPI_PMIX}")
 endif()
+
+# We require OpenMP support
+find_package(OpenMP REQUIRED)
 
 # Follow official kokkos guidelines
 # https://github.com/kokkos/kokkos/wiki/Compiling#42-using-general-cmake-build-system

--- a/examples/fodo_cxx/fodo_cxx.cc
+++ b/examples/fodo_cxx/fodo_cxx.cc
@@ -20,7 +20,7 @@
 #ifdef BUILD_FD_SPACE_CHARGE_SOLVER
 #include "synergia/collective/space_charge_3d_fd.h"
 #else
-#include "synergia/collective/Space_charge_3d_open_hockney.h"
+#include "synergia/collective/space_charge_3d_open_hockney.h"
 #endif
 
 #include "fodo_cxx_options.h"

--- a/src/synergia/utils/tests/CMakeLists.txt
+++ b/src/synergia/utils/tests/CMakeLists.txt
@@ -37,10 +37,12 @@ add_mpi_test(test_hdf5_read_mpi 2)
 add_mpi_test(test_hdf5_read_mpi 3)
 add_mpi_test(test_hdf5_read_mpi 4)
 
-add_executable(test_kokkos test_kokkos.cc)
-target_link_libraries(test_kokkos synergia_test_main)
+if("${ENABLE_KOKKOS_BACKEND}" STREQUAL "CUDA")
+  add_executable(test_kokkos test_kokkos.cc)
+  target_link_libraries(test_kokkos synergia_test_main)
 
-add_mpi_test(test_kokkos 1)
+  add_mpi_test(test_kokkos 1)
+endif()
 
 add_executable(test_commxx_mpi test_commxx_mpi.cc)
 target_link_libraries(test_commxx_mpi synergia_parallel_utils

--- a/src/synergia/utils/tests/test_kokkos.cc
+++ b/src/synergia/utils/tests/test_kokkos.cc
@@ -8,12 +8,12 @@ TEST_CASE("kokkos_padding", "[BunchParticles]")
     auto harr = Kokkos::create_mirror_view(darr);
 
     INFO("This is a test for Kokkos::AllowPadding issue on the "
-            "device memory. If it fails, meaning the issue hasnt "
-            "been fixed in Kokkos yet");
+            "device memory. If it fails, this means the issue "
+            " has been fixed in Kokkos.");
 
     REQUIRE(darr.stride(0) == harr.stride(0));
-    REQUIRE(darr.stride(1) == harr.stride(1));
+    REQUIRE(darr.stride(1) != harr.stride(1));
 
-    CHECK_NOTHROW(Kokkos::deep_copy(harr, darr));
+    CHECK_THROWS(Kokkos::deep_copy(harr, darr));
 }
 


### PR DESCRIPTION
This fixes the build on WC.

The cmake command to configure the biuld is:
```
CC=gcc CXX=g++ cmake -DKokkos_ENABLE_CUDA_LAMBDA=1 -DCMAKE_INSTALL_PREFIX=${SYNINSTALL} -DENABLE_KOKKOS_BACKEND=CUDA -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=${PY_EXE} -DKokkos_ENABLE_OPENMP=on -DGSV=DOUBLE -DKokkos_ARCH_VOLTA70=on -DCMAKE_CXX_FLAGS="-arch=sm_70" -DCMAKE_CXX_COMPILER=${SYNSRC}/src/synergia/utils/kokkos/bin/nvcc_wrapper ${SYNSRC}
```
