### PR TITLE
72 give informative message if the lattice does not have a valid reference particle

### DIFF
--- a/src/synergia/lattice/lattice.cc
+++ b/src/synergia/lattice/lattice.cc
@@ -256,15 +256,21 @@ Lattice::export_madx_file(std::string const& filename) const
     throw std::runtime_error("Lattice::as_madx_file() unable to create file");
   }
 
-  // "beam, pc={{momentum}}, particle={{particle}}"
-  mxfile << reference_particle.as_madx() << "\n\n";
 
-  // "{{element_label}} : {{element_type}}, {{attr}}={{val}}..."
-  std::unordered_set<std::string> elm_names;
-  for (auto const& e : elements) {
-    mxfile << e.as_madx() << "\n";
-    elm_names.insert(e.get_name());
-  }
+    // "beam, pc={{momentum}}, particle={{particle}}"
+    if (!reference_particle.has_value()) {
+        mxfile << "! This lattice has not defined a reference particle with BEAM statement information\n\n";
+    } else {
+        mxfile << reference_particle.value().as_madx() << "\n\n";
+    }
+    
+    // "{{element_label}} : {{element_type}}, {{attr}}={{val}}..."
+    std::unordered_set<std::string> elm_names;
+    for(auto const& e : elements)
+    {
+        mxfile << e.as_madx() << "\n";
+        elm_names.insert(e.get_name());
+    }
 
   double pos = 0.0;
   int idx = 0;

--- a/src/synergia/lattice/lattice.cc
+++ b/src/synergia/lattice/lattice.cc
@@ -95,7 +95,7 @@ Lattice::Lattice(Lsexpr const& lsexpr)
   }
 }
 
-#if 0
+#if 0 // as_lsexpr() might come back some day
 Lsexpr
 Lattice::as_lsexpr() const
 {
@@ -144,37 +144,6 @@ Lattice::append(Lattice_element const& element)
   elements.back().set_lattice(*this);
   updated.structure = true;
 }
-
-#if 0
-void
-Lattice::derive_external_attributes()
-{
-#if 0
-    bool needed = false;
-    for (Lattice_elements::const_iterator it = elements.begin();
-            it != elements.end(); ++it) {
-        if ((*it)->get_needs_external_derive()) {
-            needed = true;
-        }
-    }
-    if (needed) {
-        if (!reference_particle_allocated) {
-            throw std::runtime_error(
-                    "Lattice::derive_external_attributes requires a reference_particle");
-        }
-        double beta = reference_particle->get_beta();
-        double lattice_length = get_length();
-        for (Lattice_elements::const_iterator it = elements.begin();
-                it != elements.end(); ++it) {
-            if ((*it)->get_needs_external_derive()) {
-                element_adaptor_map_sptr->get_adaptor((*it)->get_type())->set_derived_attributes_external(
-                        *(*it), lattice_length, beta);
-            }
-        }
-    }
-#endif
-}
-#endif
 
 void
 Lattice::set_all_double_attribute(std::string const& name,

--- a/src/synergia/lattice/lattice.h
+++ b/src/synergia/lattice/lattice.h
@@ -73,7 +73,7 @@ public:
   /// @param lsexpr representation
   explicit Lattice(Lsexpr const& lsexpr);
 
-#if 0
+#if 0 // as_lsexpr() might come back some day
     /// Extract an Lsexpr representation of the Lattice
     Lsexpr
     as_lsexpr() const;
@@ -132,25 +132,14 @@ public:
   /// @param element a Lattice_element
   void append(Lattice_element const& element);
 
-#if 0
-    /// Derive internal attributes where necessary
-    void derive_internal_attributes();
-
-    /// Derive external attributes where necessary
-    void derive_external_attributes();
-
-    /// Complete all attribute updates. Includes defaults and derivations.
-    void complete_attributes();
-#endif
-
-  /// Set the value of the named double attribute on all elements
-  /// @param name attribute name
-  /// @param value attribute value
-  /// @param increment_revision can be set to false for attributes that do not
-  /// affect dynamics
-  void set_all_double_attribute(std::string const& name,
-                                double value,
-                                bool increment_revision = true);
+    /// Set the value of the named double attribute on all elements
+    /// @param name attribute name
+    /// @param value attribute value
+    /// @param increment_revision can be set to false for attributes that do not affect dynamics
+    void
+    set_all_double_attribute(
+            std::string const& name, double value,
+            bool increment_revision = true);
 
   /// Set the value of the named string attribute on all elements
   /// @param name attribute name

--- a/src/synergia/lattice/lattice.h
+++ b/src/synergia/lattice/lattice.h
@@ -35,12 +35,10 @@ public:
 private:
   std::string name;
 
-  Reference_particle reference_particle;
+  std::optional<Reference_particle> reference_particle;
   std::list<Lattice_element> elements;
 
   update_flags_t updated;
-    std::optional<Reference_particle> reference_particle;
-    std::list<Lattice_element> elements;
 
   // Lattice tree object for evaluating variables
   // in the lattice element attributes
@@ -225,16 +223,6 @@ public:
 private:
   friend class cereal::access;
 
-  template <class Archive>
-  void
-  save(Archive& ar) const
-  {
-    ar(CEREAL_NVP(name));
-    ar(CEREAL_NVP(reference_particle));
-    ar(CEREAL_NVP(elements));
-    ar(CEREAL_NVP(updated));
-    ar(CEREAL_NVP(tree));
-  }
 
     template<class Archive>
     void save(Archive & ar) const

--- a/src/synergia/lattice/lattice_element.cc
+++ b/src/synergia/lattice/lattice_element.cc
@@ -137,8 +137,9 @@ Lattice_element::Lattice_element(Lsexpr const& lsexpr)
 Lsexpr
 Lattice_element::as_lsexpr() const
 {
-  Lsexpr retval;
-#if 0
+
+    Lsexpr retval;
+#if 0 // as_lsexpr() might come back some day
     retval.push_back(Lsexpr(type, "type"));
     retval.push_back(Lsexpr(name, "name"));
     if (double_attributes.size() > 0) {

--- a/src/synergia/lattice/tests/test_lattice.py
+++ b/src/synergia/lattice/tests/test_lattice.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+import pytest
 from synergia.lattice import Lattice, Lattice_element
 from synergia.foundation import Reference_particle
 
@@ -26,3 +26,9 @@ def test_get_reference_particle():
     reference_particle = Reference_particle(charge, mass, total_energy)
     lattice.set_reference_particle(reference_particle)
     assert(lattice.get_reference_particle().equal(reference_particle, tolerance))
+
+def test_throws_without_reference_particle():
+    lattice = Lattice(name)
+    with pytest.raises(RuntimeError):
+        lattice.get_reference_particle()
+


### PR DESCRIPTION
Made Lattice::reference_particle an std::optional member with logic to check whether its value has been set.  Resolves Issue#72.