### PR TITLE
Manage Eigen3 dependency as a target

### DIFF
--- a/.github/workflows/macos-clang.yml
+++ b/.github/workflows/macos-clang.yml
@@ -68,6 +68,8 @@ jobs:
       run: |
         source ${{github.workspace}}/synergia-env/bin/activate
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+         -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+         -DCMAKE_PREFIX_PATH="/usr/local/Cellar/libomp/15.0.2" \
          -DENABLE_KOKKOS_BACKEND=OpenMP -DBUILD_PYTHON_BINDINGS=on -DBUILD_EXAMPLES=off -GNinja
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,9 @@ endif()
 
 project(SYNERGIA2 LANGUAGES CXX C)
 
-
 if(${CMAKE_VERSION} VERSION_GREATER "3.22.0")
-    cmake_policy(SET CMP0127 OLD) # remove this when we move to CMake 3.22
+  cmake_policy(SET CMP0127 OLD) # remove this when we move to CMake 3.22
 endif()
-
 
 # generate compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -335,6 +333,17 @@ else()
   message(STATUS "using double for gsvector")
 endif()
 
+# Find Eigen, a dependency we vendor
+message(STATUS "Configuring Eigen3 for use in host routines.")
+# Eigen tries to determine fortran compiler ID via FC, which can cause issues
+# with flang-new, so unset that temporarily.
+set(FC_BACKUP $ENV{FC})
+unset(ENV{FC})
+add_subdirectory(${SYNERGIA2_SOURCE_DIR}/src/synergia/utils/eigen)
+set(ENV{FC} ${FC_BACKUP})
+find_package(Eigen3 REQUIRED PATHS
+             ${SYNERGIA2_SOURCE_DIR}/src/synergia/utils/eigen)
+
 # Additional CXXFLAGS
 if(EXTRA_CXX_FLAGS)
   string(APPEND CMAKE_CXX_FLAGS ${EXTRA_CXX_FLAGS})
@@ -349,7 +358,6 @@ configure_file("${SYNERGIA2_SOURCE_DIR}/synergia-local.in"
 configure_file("${SYNERGIA2_SOURCE_DIR}/src/local_paths.py.in"
                "${SYNERGIA2_BINARY_DIR}/src/local_paths.py" IMMEDIATE)
 
-include_directories(BEFORE ${SYNERGIA2_SOURCE_DIR}/src/synergia/utils/eigen)
 include_directories(BEFORE ${SYNERGIA2_SOURCE_DIR}/src/synergia/utils
 )# for boost headers
 include_directories(BEFORE ${SYNERGIA2_SOURCE_DIR}/src)

--- a/examples/s3_sis18/CMakeLists.txt
+++ b/examples/s3_sis18/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(trigon
 
 add_executable(tmapping tmapping.cc)
 target_link_libraries(tmapping
+	synergia_foundation
 	synergia_serialization
 	${kokkos_libs}
 	)

--- a/examples/s3_sis18/tmapping.cc
+++ b/examples/s3_sis18/tmapping.cc
@@ -2,8 +2,8 @@
 #include "synergia/foundation/trigon.h"
 #include <iostream>
 
-
-void evaluation()
+void
+evaluation()
 {
     using Tri = Trigon<double, 3, 3>;
 
@@ -16,15 +16,15 @@ void evaluation()
     std::cout << "y = " << y << "\n";
 
     // functions
-    auto f = exp(x)*exp(y);
+    auto f = exp(x) * exp(y);
     auto g = kt::qpow(f, 3);
-    auto k = x + y + x*y + y*z + z*z;
+    auto k = x + y + x * y + y * z + z * z;
 
     std::cout << "f = exp(x)*exp(y) = " << f << "\n";
     std::cout << "g = qpow(f,3) = " << g << "\n";
     std::cout << "k = x+y+xy+yz+zz = " << k << "\n";
 
-    // evaluate functions at this coordinate 
+    // evaluate functions at this coordinate
     arr_t<double, 3> v{0.1, 0.2, 1.0};
 
     std::cout << "f(v) = " << f(v) << "\n";
@@ -32,9 +32,10 @@ void evaluation()
     std::cout << "k(v) = " << k(v) << "\n\n";
 }
 
-void composition()
+void
+composition()
 {
-    using Tri = Trigon<double, 3/*power*/, 2/*dim*/>;
+    using Tri = Trigon<double, 3 /*power*/, 2 /*dim*/>;
 
     // coordinates mapping a
     Tri x(0.0, 0);
@@ -45,8 +46,8 @@ void composition()
 
     // mapping of a
     TMapping<Tri> a;
-    a[0] = x*y*y + exp(x+y);
-    a[1] = cos(y*x*x) / (x+2.0);
+    a[0] = x * y * y + exp(x + y);
+    a[1] = cos(y * x * x) / (x + 2.0);
 
     std::cout << "a[0] = " << a[0] << "\n";
     std::cout << "a[1] = " << a[1] << "\n";
@@ -58,7 +59,7 @@ void composition()
     // mapping b
     TMapping<Tri> b;
     b[0] = sin(xx) * cos(yy);
-    b[1] = exp(xx*xx*xx) / (xx*yy);
+    b[1] = exp(xx * xx * xx) / (xx * yy);
 
     std::cout << "b[0] = " << b[0] << "\n";
     std::cout << "b[1] = " << b[1] << "\n";
@@ -70,11 +71,12 @@ void composition()
     std::cout << "c[1] = " << c[1] << "\n";
 
     // direct concat
-    Tri q = x*y*y + exp(x+y);
-    Tri v = cos(y*x*x) / (x+2.0);;
+    Tri q = x * y * y + exp(x + y);
+    Tri v = cos(y * x * x) / (x + 2.0);
+    ;
 
-    Tri w = sin(q)*cos(v);
-    Tri z = exp(q*q*q) / (q*v);
+    Tri w = sin(q) * cos(v);
+    Tri z = exp(q * q * q) / (q * v);
 
     std::cout << "w = " << w << "\n";
     std::cout << "z = " << z << "\n";
@@ -82,16 +84,16 @@ void composition()
     return;
 }
 
-int main(int argc, char ** argv)
+int
+main(int argc, char** argv)
 {
-    //MPI_Init(&argc, &argv);
-    //Kokkos::initialize(argc, argv);
+    // MPI_Init(&argc, &argv);
+    // Kokkos::initialize(argc, argv);
 
     evaluation();
     composition();
 
-    //Kokkos::finalize();
-    //MPI_Finalize();
+    // Kokkos::finalize();
+    // MPI_Finalize();
     return 0;
 }
-

--- a/src/synergia/bunch/CMakeLists.txt
+++ b/src/synergia/bunch/CMakeLists.txt
@@ -1,6 +1,8 @@
 # This library is built separately to avoid linking to kokkos directly and avoid
 # calling host only functions from host-device code.
 add_library(synergia_bunch_hostonly diagnostics_full2_host.cc populate_host.cc)
+target_link_libraries(synergia_bunch_hostonly PUBLIC Eigen3::Eigen)
+target_compile_definitions(synergia_bunch_hostonly PUBLIC EIGEN_NO_CUDA)
 target_link_options(synergia_bunch_hostonly PRIVATE ${LINKER_OPTIONS})
 
 add_library(

--- a/src/synergia/foundation/CMakeLists.txt
+++ b/src/synergia/foundation/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(synergia_foundation four_momentum.cc reference_particle.cc
                                 distribution.cc)
-
+target_compile_definitions(synergia_foundation PUBLIC EIGEN_NO_CUDA)
 target_link_libraries(synergia_foundation synergia_parallel_utils lsexpr
-                      GSL::gsl GSL::gslcblas)
+                      GSL::gsl GSL::gslcblas Eigen3::Eigen)
 
 target_link_options(synergia_foundation PRIVATE ${LINKER_OPTIONS})
 

--- a/src/synergia/lattice/CMakeLists.txt
+++ b/src/synergia/lattice/CMakeLists.txt
@@ -3,7 +3,9 @@
 add_library(synergia_lattice_hostonly mx_expr.cc mx_parse.cc mx_tree.cc madx.cc
                                       lattice_tree.cc)
 target_link_libraries(synergia_lattice_hostonly synergia_foundation)
-target_compile_definitions(synergia_lattice_hostonly PUBLIC BOOST_NO_CXX98_FUNCTION_BASE)
+target_compile_definitions(synergia_lattice_hostonly PUBLIC EIGEN_NO_CUDA)
+target_compile_definitions(synergia_lattice_hostonly
+                           PUBLIC BOOST_NO_CXX98_FUNCTION_BASE)
 target_compile_definitions(synergia_lattice_hostonly PUBLIC BOOST_NO_CXX03)
 target_link_options(synergia_lattice_hostonly PRIVATE ${LINKER_OPTIONS})
 

--- a/src/synergia/simulation/CMakeLists.txt
+++ b/src/synergia/simulation/CMakeLists.txt
@@ -6,6 +6,8 @@ target_link_options(synergia_bunchsim PRIVATE ${LINKER_OPTIONS})
 
 add_library(synergia_simulation_hostonly checkpoint_json.cc
                                          lattice_simulator_host.cc)
+target_compile_definitions(synergia_simulation_hostonly PUBLIC EIGEN_NO_CUDA)
+target_link_libraries(synergia_simulation_hostonly Eigen3::Eigen)
 target_link_options(synergia_simulation_hostonly PRIVATE ${LINKER_OPTIONS})
 
 add_library(


### PR DESCRIPTION
This is to let `Eigen3` use SIMD/OpenMP parallelism on the host. A preprocessor directive `EIGEN_NO_CUDA` has also been added to prevent `Eigen3` routines from being compiled as `__host__ __device__` functions. 

`Eigen3` uses `cmake` to detect the Fortran compiler (though this is not a necessity). However, with `flang-new` (built as part of LLVM-15.0.2) and `cmake-3.24.2`, this compiler detection fails leading to the `cmake` phase erroring out. To prevent this, the `FC` environment variable is temporarily unset. This workaround can be removed when newer versions of `cmake` can detect `flang-new` properly. 