### PR TITLE
CI: macos updates

### DIFF
--- a/.github/workflows/macos-clang.yml
+++ b/.github/workflows/macos-clang.yml
@@ -38,6 +38,10 @@ jobs:
       with:
         submodules: 'true'
 
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10' 
+
     - name: Dependencies
       run: |
         brew install gsl hdf5 fftw libomp ninja
@@ -45,17 +49,8 @@ jobs:
         source ${{github.workspace}}/synergia-env/bin/activate
         python3 -m pip install --upgrade pip setuptools wheel
         python3 -m pip install cython matplotlib mpi4py numpy pyparsing pytest
-        # We do not install h5py because the pip-installed version may not use
-        # a version of HDF5 that matches what we have from Homebrew. Instead,
-        # we build our own from source.
-        mkdir tmp
-        cd tmp
-        wget https://github.com/h5py/h5py/archive/refs/tags/3.7.0.tar.gz
-        tar xf 3.7.0.tar.gz
-        cd h5py-3.7.0
-        HDF5_DIR=/usr/local python setup.py install
-        cd ../..
-        rm -r tmp/
+        # Build h5py from source using the Homebrew installed hdf5
+        HDF5_DIR=$(brew --prefix hdf5) python3 -m pip install --no-binary=h5py h5py
 
     # Debug: checkpoint at which to open tmate session
     - name: Setup tmate session
@@ -70,6 +65,7 @@ jobs:
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
          -DCMAKE_PREFIX_PATH=$(brew --prefix libomp) \
+         -DPython_EXECUTABLE=${{github.workspace}}/synergia-env/bin/python3.10 \
          -DENABLE_KOKKOS_BACKEND=OpenMP -DBUILD_PYTHON_BINDINGS=on -DBUILD_EXAMPLES=off -GNinja
 
     - name: Build

--- a/.github/workflows/macos-gcc.yml
+++ b/.github/workflows/macos-gcc.yml
@@ -28,9 +28,9 @@ jobs:
       with:
         submodules: 'true'
 
-    - uses: maxim-lobanov/setup-xcode@v1
+    - uses: actions/setup-python@v4
       with:
-        xcode-version: latest      
+        python-version: '3.10' 
 
     - name: Dependencies
       run: |
@@ -39,17 +39,8 @@ jobs:
         source ${{github.workspace}}/synergia-env/bin/activate
         python3 -m pip install --upgrade pip setuptools wheel
         python3 -m pip install cython matplotlib mpi4py numpy pyparsing pytest
-        # We do not install h5py because the pip-installed version may not use
-        # a version of HDF5 that matches what we have from Homebrew. Instead,
-        # we build our own from source.
-        mkdir tmp
-        cd tmp
-        wget https://github.com/h5py/h5py/archive/refs/tags/3.7.0.tar.gz
-        tar xf 3.7.0.tar.gz
-        cd h5py-3.7.0
-        HDF5_DIR=/usr/local python setup.py install
-        cd ../..
-        rm -r tmp/
+        # Build h5py from source using the Homebrew installed hdf5
+        HDF5_DIR=$(brew --prefix hdf5) python3 -m pip install --no-binary=h5py h5py
 
     - name: CMake
       run: |
@@ -58,6 +49,7 @@ jobs:
         -DCMAKE_OSX_ARCHITECTURES="x86_64" \
         -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 \
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_KOKKOS_BACKEND=OpenMP \
+        -DPython_EXECUTABLE=${{github.workspace}}/synergia-env/bin/python3.10 \
         -DBUILD_PYTHON_BINDINGS=on -DBUILD_EXAMPLES=off -GNinja
 
     - name: Build

--- a/.github/workflows/macos-gcc.yml
+++ b/.github/workflows/macos-gcc.yml
@@ -28,6 +28,10 @@ jobs:
       with:
         submodules: 'true'
 
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest
+
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10' 


### PR DESCRIPTION
Use python3.10, until h5py supports 3.11