### PR TITLE
Pass shared_ptr to c'tor by rvalue ref

### DIFF
--- a/src/synergia/utils/commxx.cc
+++ b/src/synergia/utils/commxx.cc
@@ -45,7 +45,7 @@ Commxx::construct()
   if (newcomm != MPI_COMM_NULL) comm.reset(new MPI_Comm(newcomm), comm_free());
 }
 
-Commxx::Commxx(std::shared_ptr<const Commxx> const& parent, int color, int key)
+Commxx::Commxx(std::shared_ptr<const Commxx>&& parent, int color, int key)
   : comm()
   , parent_comm(std::move(parent))
   , type(comm_type::regular)

--- a/src/synergia/utils/commxx.h
+++ b/src/synergia/utils/commxx.h
@@ -45,7 +45,7 @@ private:
   int color, key;
 
 private:
-  Commxx(std::shared_ptr<const Commxx> const& parent, int color, int key);
+  Commxx(std::shared_ptr<const Commxx>&& parent, int color, int key);
   void construct();
 
 public:


### PR DESCRIPTION
Because all uses of the constructor in question pass an unnamed (temporary) object, there is no current use that is dangerous. To avoid the introduction of problem code, this commit changes the signature of the constructor from passing the `shared_ptr` by `const&` to `&&` (const lvalue reference to rvalue reference). This makes sure that the constructor will only work for rvalues, for example unnamed temporary objects.