### PR TITLE
Added example files booster_map.py to print out nonlinear maps for an

### DIFF
--- a/examples/normal_form/README.md
+++ b/examples/normal_form/README.md
@@ -1,0 +1,11 @@
+# Normal form and mapping examples
+
+1. `normal_form.cc` Propagate particles through a nonlinear lattice, write out normal form coordinates.
+
+2. `normal_form.py` Propagate particles through a nonlinear lattice, write out normal form coordinates in Python.
+
+3. `channel_map.cc` Read in lattice file `channel.madx`. Print out nonlinear terms in the one-turn map using trigon.
+
+4. `channel_map.py` Read in lattice file `channel.madx`. Print out nonlinear terms in the one-turn map using trigon.
+
+5. `booster_map.py` Read in a simplified booster lattice in json form from file `booster_init_lattice.json`. Print out nonliner terms in the one-turn map using trigon.

--- a/examples/normal_form/booster_init_lattice.json
+++ b/examples/normal_form/booster_init_lattice.json
@@ -1,0 +1,11663 @@
+{
+    "value0": {
+        "name": "booster",
+        "has_reference_particle": true,
+        "reference_particle_value": {
+            "charge": 1,
+            "four_momentum": {
+                "mass": 0.938272046,
+                "energy": 1.738272046,
+                "momentum": 1.4632960307470256,
+                "gamma": 1.8526311781434018,
+                "beta": 0.8418107131816728
+            },
+            "state": {
+                "value0": 0.0,
+                "value1": 0.0,
+                "value2": 0.0,
+                "value3": 0.0,
+                "value4": 0.0,
+                "value5": 0.0
+            },
+            "repetition": 0,
+            "s": 0.0,
+            "s_n": 0.0
+        },
+        "elements": [
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu01",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu01",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd01",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd01",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu02",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu02",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd02",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd02",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu03",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu03",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd03",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd03",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu04",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu04",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd04",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd04",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu05",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu05",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd05",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd05",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu06",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu06",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd06",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd06",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu07",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu07",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd07",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd07",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu08",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu08",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd08",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd08",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu09",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu09",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd09",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd09",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu10",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu10",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd10",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd10",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu11",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu11",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd11",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd11",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu12",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu12",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd12",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd12",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu13",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu13",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d3",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "6"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd13",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd13",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu14",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu14",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd14",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd14",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu15",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu15",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd15",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd15",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu16",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu16",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd16",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd16",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu17",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu17",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd17",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd17",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu18",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu18",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd18",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd18",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu19",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu19",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd19",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd19",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu20",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu20",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd20",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd20",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu21",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu21",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd21",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd21",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu22",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu22",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd22",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd22",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu23",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu23",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd23",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd23",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d1",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagu24",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d2",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagu24",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnna",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2099999999999999922"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnb",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1199999999999999956"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "rfc",
+                "format": 1,
+                "stype": "rfcavity",
+                "type": 6,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "freq",
+                        "value": {
+                            "value0": "44.70440998524428977"
+                        }
+                    },
+                    {
+                        "key": "harmon",
+                        "value": {
+                            "value0": "84"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "lag",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "shunt",
+                        "value": {
+                            "value0": "0"
+                        }
+                    },
+                    {
+                        "key": "volt",
+                        "value": {
+                            "value0": "0.009090909090909092202"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 21,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drrf",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "1.175000000000000044"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnc",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.25"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "hpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "vpnnl",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.09500000000000000111"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnnd",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1110000000000000014"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "cplnn",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.1680000000000000104"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "drlnne",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.2510000000000000009"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "dmagd24",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "-0.0573885501199999995"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d4",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "fmagd24",
+                "format": 1,
+                "stype": "quadrupole",
+                "type": 4,
+                "ancestors": [],
+                "string_attributes": [
+                    {
+                        "key": "propagator_type",
+                        "value": "yoshida"
+                    }
+                ],
+                "lazy_double_attributes": [
+                    {
+                        "key": "k1",
+                        "value": {
+                            "value0": "0.05410921560999999713"
+                        }
+                    },
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "2.889612000000000069"
+                        }
+                    },
+                    {
+                        "key": "yoshida_order",
+                        "value": {
+                            "value0": "2"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 6,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            },
+            {
+                "name": "d5",
+                "format": 1,
+                "stype": "drift",
+                "type": 1,
+                "ancestors": [],
+                "string_attributes": [],
+                "lazy_double_attributes": [
+                    {
+                        "key": "l",
+                        "value": {
+                            "value0": "0.5999999999999999778"
+                        }
+                    }
+                ],
+                "lazy_vector_attributes": [],
+                "length_attribute_name": "l",
+                "bend_angle_attribute_name": "angle",
+                "revision": 1,
+                "markers": {
+                    "value0": false,
+                    "value1": false,
+                    "value2": false,
+                    "value3": false
+                }
+            }
+        ],
+        "updated": {
+            "value0": true,
+            "value1": true,
+            "value2": true
+        },
+        "tree": {
+            "value0": ""
+        }
+    }
+}

--- a/examples/normal_form/booster_map.py
+++ b/examples/normal_form/booster_map.py
@@ -1,0 +1,68 @@
+
+import numpy as np
+import synergia as syn
+
+def run():
+
+    # logger
+    screen = syn.utils.parallel_utils.Logger(0, 
+            syn.utils.parallel_utils.LoggerV.DEBUG)
+
+    simlog = syn.utils.parallel_utils.Logger(0, 
+            syn.utils.parallel_utils.LoggerV.INFO_TURN)
+
+    # lattice
+    with open('booster_init_lattice.json', 'r') as f:
+        jslattice = f.read()
+    lattice = syn.lattice.Lattice.load_from_json(jslattice)
+    print('lattice length: ', lattice.get_length())
+    print('lattice energy: ', lattice.get_reference_particle().get_total_energy())
+    syn.simulation.Lattice_simulator.tune_circular_lattice(lattice)
+
+    # calculate one turn map at given order (3 here)
+    mapping = syn.simulation.Lattice_simulator.get_one_turn_map_o3(lattice)
+
+    # save
+    mapping.save_json("mapping.json")
+
+    # load
+    m2 = syn.foundation.TMapping_o3.load_json("mapping.json")
+
+    # create the normal form object from one turn mapping directly
+    ref = lattice.get_reference_particle()
+    e0 = ref.get_total_energy()
+    pc0 = ref.get_momentum()
+    mass = ref.get_mass()
+
+    nf = syn.foundation.NormalForm_o3(m2, e0, pc0, mass)
+
+    # save nf
+    nf.save_json("nf.json")
+
+    # load
+    nf2 = syn.foundation.NormalForm_o3.load_json("nf.json")
+
+    # convert the mapping to a json object
+    mapping_json = mapping.to_json()
+    print(mapping_json)
+
+    # or iterate through the components and fields
+    for comp in range(6):
+        trigon = mapping.component(comp)
+        print("\n\nComponent {}".format(comp))
+
+        for pwr in range(trigon.power()+1):
+           for idx in range(trigon.count(pwr)): 
+               idx_to_exp = "syn.foundation.Trigon_index_to_exp_o{}(idx)".format(pwr)
+
+               print('power = {}, exp = {}, term = {}'.format( 
+                    pwr, eval(idx_to_exp), trigon.get_term(pwr, idx)))
+
+
+
+print("channel_map")
+run()
+
+
+
+


### PR DESCRIPTION
example simplified Booster model contained in json file booster_init_lattice.json.

Also added README.

New example shows how to load a json lattice in Python.
