### PR TITLE
Fix python bindings for Bunch::get_x_reference_particle with tests also for Propagator::get_lattice().get_x_reference_particle

### DIFF
--- a/src/synergia/bunch/bunch_pywrap.cc
+++ b/src/synergia/bunch/bunch_pywrap.cc
@@ -98,12 +98,13 @@ PYBIND11_MODULE(bunch, m)
 
     .def("get_reference_particle",
          (Reference_particle & (Bunch::*)()) & Bunch::get_reference_particle,
-         "Get the reference particle of the bunch.")
+          py::return_value_policy::reference,
+         "Get the reference particle of the bunch. Returns reference to object")
 
     .def("get_design_reference_particle",
          (Reference_particle & (Bunch::*)()) &
            Bunch::get_design_reference_particle,
-         "Get the design reference particle of the bunch.")
+         "Get a copy of the design reference particle of the bunch.")
 
     .def("checkout_particles",
          &Bunch::checkout_particles,

--- a/src/synergia/bunch/tests/CMakeLists.txt
+++ b/src/synergia/bunch/tests/CMakeLists.txt
@@ -9,3 +9,5 @@ add_mpi_test(test_bunch 1)
 add_executable(test_bunch_particles test_bunch_particles.cc)
 target_link_libraries(test_bunch_particles synergia_bunch synergia_test_main)
 add_mpi_test(test_bunch_particles 1)
+
+add_py_test(test_bunch_reference_particles.py)

--- a/src/synergia/bunch/tests/test_bunch_reference_particles.py
+++ b/src/synergia/bunch/tests/test_bunch_reference_particles.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import pytest
+import numpy
+import synergia
+
+mass = 1.0
+betagamma = 3/4
+gamma = 5/4
+energy = mass*gamma
+
+@pytest.fixture
+def bunch_fixture():
+    refpart = synergia.foundation.Reference_particle(1, mass, energy)
+    macroparticles=10
+    realparticles=5e10
+    bunch = synergia.bunch.Bunch(refpart, macroparticles, realparticles, synergia.utils.Commxx())
+    return bunch
+
+def test_bunch_refpart(bunch_fixture):
+    assert bunch_fixture.get_reference_particle().get_total_energy() == energy
+    new_energy = energy+1.0
+    bunch_fixture.get_reference_particle().set_total_energy(new_energy)
+    assert bunch_fixture.get_reference_particle().get_total_energy() == new_energy
+
+def test_bunch_design_refpart(bunch_fixture):
+    assert bunch_fixture.get_design_reference_particle().get_total_energy() == energy
+    new_energy = energy+1.0
+    bunch_fixture.get_design_reference_particle().set_total_energy(new_energy)
+    # the energy should not have changed because this is not a binding-by-reference
+    assert bunch_fixture.get_design_reference_particle().get_total_energy() == energy
+

--- a/src/synergia/simulation/simulation_pywrap.cc
+++ b/src/synergia/simulation/simulation_pywrap.cc
@@ -53,11 +53,12 @@ PYBIND11_MODULE(simulation, m)
 
     .def("print_steps", &Propagator::print_steps)
 
-    .def("get_lattice_element_slices", &Propagator::get_lattice_element_slices)
+    .def("get_lattice_element_slices", &Propagator::get_lattice_element_slices, "Returns immutable copy of lattice element slices")
 
-    .def("get_lattice_elements", &Propagator::get_lattice_elements)
+    .def("get_lattice_elements", &Propagator::get_lattice_elements, "Returns immutable copy of lattice elements")
 
-    .def("get_lattice", py::overload_cast<>(&Propagator::get_lattice, py::const_), py::return_value_policy::reference)
+    .def("get_lattice", py::overload_cast<>(&Propagator::get_lattice, py::const_), py::return_value_policy::reference,
+        "Returns immutable reference to the lattice, but the attributes of the elements contained with may be modified with set_<>_attribute member functions")
 
     .def(
       "set_checkpoint_period", &Propagator::set_checkpoint_period, "period"_a)

--- a/src/synergia/simulation/tests/test_propagator.py
+++ b/src/synergia/simulation/tests/test_propagator.py
@@ -55,7 +55,12 @@ def test_modify_lattice_elements(prop_fixture):
     assert slices[0].get_lattice_element().get_double_attribute('a1') == new_a1
     return 0
 
-
+def test_modify_reference_particle_energy(prop_fixture):
+    orig_energy = prop_fixture['propagator'].get_lattice().get_reference_particle().get_total_energy()
+    new_energy = orig_energy + 2.0
+    prop_fixture['propagator'].get_lattice().get_reference_particle().set_total_energy(new_energy)
+    assert prop_fixture['propagator'].get_lattice().get_reference_particle().get_total_energy() == new_energy
+    return True
 
 def test_set_get_checkpoint(prop_fixture):
     init_period = prop_fixture['propagator'].get_checkpoint_period()


### PR DESCRIPTION
immutable binding for Bunch::get_design_reference_particle
mutable binding for Bunch::get_reference_particle
tests for those bindings and also for Propagator::get_lattice::get_reference_particle()
Fixes Issue#122