### PR TITLE
Fixed the trigon log going explode at high orders.

### DIFF
--- a/src/synergia/foundation/trigon.h
+++ b/src/synergia/foundation/trigon.h
@@ -1963,7 +1963,7 @@ log_derivatives(T x, unsigned int power)
   T invx(1.0 / x);
   T powinvx = 1.0;
   T fact = 1.0;
-  for (size_t i = 1; i < power; ++i) {
+  for (int i = 1; i < power; ++i) {
     powinvx *= invx;
     if (i > 1) { fact *= -(i - 1); }
     retval[i] = fact * powinvx;


### PR DESCRIPTION
The loop index `i` was of type `size_t` which causes the `-(i-1)` to wrap around and becomes 2^64-1 when calculating the `factor`. 

The problem has caused CF sbend normal form calculation to fail at high orders because the kick function uses the `log()` of the Trigon particle.