### PR TITLE
on ppc64le don't vectorize eigen calls

### DIFF
--- a/CMake/MPITest.cmake
+++ b/CMake/MPITest.cmake
@@ -9,6 +9,7 @@ macro(add_mpi_test tname np)
                 OMP_PROC_BIND=spread
                 OMP_PLACES=cores
                 OMPI_MCA_rmaps_base_oversubscribe=true
+		PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
                 ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np}
                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${tname}> ${MPIEXEC_POSTFLAGS})
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,10 @@ message(STATUS "Configuring Eigen3 for use in host routines.")
 # with flang-new, so unset that temporarily.
 set(FC_BACKUP $ENV{FC})
 unset(ENV{FC})
+# https://gitlab.com/libeigen/eigen/-/issues/848
+set(eigen_defs
+    EIGEN_NO_CUDA
+    $<$<STREQUAL:${CMAKE_HOST_SYSTEM_PROCESSOR},ppc64le>:EIGEN_DONT_VECTORIZE>)
 add_subdirectory(${SYNERGIA2_SOURCE_DIR}/src/synergia/utils/eigen)
 set(ENV{FC} ${FC_BACKUP})
 find_package(Eigen3 REQUIRED PATHS

--- a/src/synergia/bunch/CMakeLists.txt
+++ b/src/synergia/bunch/CMakeLists.txt
@@ -2,7 +2,7 @@
 # calling host only functions from host-device code.
 add_library(synergia_bunch_hostonly diagnostics_full2_host.cc populate_host.cc)
 target_link_libraries(synergia_bunch_hostonly PUBLIC Eigen3::Eigen)
-target_compile_definitions(synergia_bunch_hostonly PUBLIC EIGEN_NO_CUDA)
+target_compile_definitions(synergia_bunch_hostonly PUBLIC ${eigen_defs})
 target_link_options(synergia_bunch_hostonly PRIVATE ${LINKER_OPTIONS})
 
 add_library(

--- a/src/synergia/foundation/CMakeLists.txt
+++ b/src/synergia/foundation/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(synergia_foundation four_momentum.cc reference_particle.cc
                                 distribution.cc)
-target_compile_definitions(synergia_foundation PUBLIC EIGEN_NO_CUDA)
+target_compile_definitions(synergia_foundation PUBLIC ${eigen_defs})
 target_link_libraries(synergia_foundation synergia_parallel_utils lsexpr
                       GSL::gsl GSL::gslcblas Eigen3::Eigen ${kokkos_libs})
 

--- a/src/synergia/lattice/CMakeLists.txt
+++ b/src/synergia/lattice/CMakeLists.txt
@@ -3,7 +3,7 @@
 add_library(synergia_lattice_hostonly mx_expr.cc mx_parse.cc mx_tree.cc madx.cc
                                       lattice_tree.cc)
 target_link_libraries(synergia_lattice_hostonly synergia_foundation)
-target_compile_definitions(synergia_lattice_hostonly PUBLIC EIGEN_NO_CUDA)
+target_compile_definitions(synergia_lattice_hostonly PUBLIC ${eigen_defs})
 target_link_options(synergia_lattice_hostonly PRIVATE ${LINKER_OPTIONS})
 
 add_library(

--- a/src/synergia/simulation/CMakeLists.txt
+++ b/src/synergia/simulation/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_options(synergia_bunchsim PRIVATE ${LINKER_OPTIONS})
 
 add_library(synergia_simulation_hostonly checkpoint_json.cc
                                          lattice_simulator_host.cc)
-target_compile_definitions(synergia_simulation_hostonly PUBLIC EIGEN_NO_CUDA)
+target_compile_definitions(synergia_simulation_hostonly PUBLIC ${eigen_defs})
 target_link_libraries(synergia_simulation_hostonly Eigen3::Eigen ${kokkos_libs})
 target_link_options(synergia_simulation_hostonly PRIVATE ${LINKER_OPTIONS})
 


### PR DESCRIPTION
Current build gives errors:
```
/wclustre/accelsim/sajid/packages/synergia2/src/synergia/utils/eigen/Eigen/src/Core/arch/AltiVec/PacketMath.h(1194): error: identifier "__builtin_vec_ceil" is undefined
                                                                                      __builtin_vec_ceil
                                                                                      ^

/wclustre/accelsim/sajid/packages/synergia2/src/synergia/utils/eigen/Eigen/src/Core/arch/AltiVec/PacketMath.h(1195): error: identifier "__builtin_vec_floor" is undefined
                                                                                      __builtin_vec_floor
                                                                                      ^

/wclustre/accelsim/sajid/packages/synergia2/src/synergia/utils/eigen/Eigen/src/Core/arch/AltiVec/PacketMath.h(1360): error: identifier "__builtin_vec_perm" is undefined
          __builtin_vec_perm
          ^

/wclustre/accelsim/sajid/packages/synergia2/src/synergia/utils/eigen/Eigen/src/Core/arch/AltiVec/PacketMath.h(1368): error: identifier "__builtin_vec_perm" is undefined
          __builtin_vec_perm
          ^

/wclustre/accelsim/sajid/packages/synergia2/src/synergia/utils/eigen/Eigen/src/Core/arch/AltiVec/PacketMath.h(1513): error: identifier "__builtin_vec_ste" is undefined
                                                                                                    __builtin_vec_ste
                                                                                                    ^

/wclustre/accelsim/sajid/packages/synergia2/src/synergia/utils/eigen/Eigen/src/Core/arch/AltiVec/PacketMath.h(1514): error: identifier "__builtin_vec_ste" is undefined
                                                                                                    __builtin_vec_ste
                                                                                                    ^
```