### PR TITLE
version.py.in: ignore HDF5 patch numbers

### DIFF
--- a/src/synergia/version.py.in
+++ b/src/synergia/version.py.in
@@ -14,4 +14,4 @@ python_interp_version = (
 mpi_library_version = "${SYNERGIA_MPI_LIBRARY_VERSION}"
 
 hdf5_library_version = "${HDF5_VERSION}"
-hdf5_library_version_tuple = tuple(int(i) for i in hdf5_library_version.split(".")) 
+hdf5_library_version_tuple = tuple(int(i.split("-")[0]) for i in hdf5_library_version.split(".")) 


### PR DESCRIPTION
The [latest release of HDF5](https://github.com/HDFGroup/hdf5/releases/tag/hdf5-1_14_1-2) is version `1.14.1-2`, which causes our current versioning logic to fail with:
```
>   hdf5_library_version_tuple = tuple(int(i) for i in hdf5_library_version.split("."))
E   ValueError: invalid literal for int() with base 10: '1-2'
```
Fix the issue by ignoring patch versions.