### PR TITLE
Egstern/193 closed orbit time calculated for booster is smaller than actual length would indicate

### DIFF
--- a/src/synergia/libFF/ff_rfcavity.h
+++ b/src/synergia/libFF/ff_rfcavity.h
@@ -230,7 +230,6 @@ namespace FF_rfcavity {
         double ref_l_y = ref_l.get_state()[Bunch::y];
         double ref_l_yp = ref_l.get_state()[Bunch::yp];
         double ref_l_cdt = 0.0;
-//        double ref_l_dpop = ref_l.get_state()[Bunch::dpop];
         // EGS: Don't use reference dpop, for calculation of cdt
         double ref_l_dpop = 0.0;
 
@@ -287,12 +286,12 @@ namespace FF_rfcavity {
         total_ref_cdt += ref_l_cdt;
         rp.ref_cdt_2 = ref_l_cdt;
 
-        // save the state, except for the longitudinal
-        //ref_l.set_state(
-        //    ref_l_x, ref_l_xp, ref_l_y, ref_l_yp, total_ref_cdt, ref_l_dpop);
-        // EGS: only update transverse coordinates of reference particle
+        // save the new state. The cdt has to be saved so that the transit time
+	// in the RF cavity is accounted for. We don't save the new dp/p here but all
+	// elements should not use it as their starting value in reference time
+	// calculation.
         ref_l.set_state(
-            ref_l_x, ref_l_xp, ref_l_y, ref_l_yp, 0.0, 0.0);
+            ref_l_x, ref_l_xp, ref_l_y, ref_l_yp, total_ref_cdt, 0.0);
 
         // bunch particles
         auto apply = [&](ParticleGroup pg) {

--- a/src/synergia/libFF/tests/test_zeroparticle2_propagate.cc
+++ b/src/synergia/libFF/tests/test_zeroparticle2_propagate.cc
@@ -99,6 +99,14 @@ void propagate_test_elem(std::string const& elem_def, double tolerance)
     for(int i=0; i<4; ++i) {
         CHECK (std::abs(parts(0, i)) < tolerance);
     }
+
+    // Make sure elapsed c dt matches element length
+    Reference_particle const& refpart = b.get_design_reference_particle();
+    double cdtlength = refpart.get_state()[4]*refpart.get_beta();
+    double elem_length = pf.lattice.get_length();
+
+    CHECK( abs(1-cdtlength/elem_length) < 1.0e-7 );
+
 }
 
 TEST_CASE("sbend")

--- a/src/synergia/libFF/tests/test_zeroparticle_propagate.cc
+++ b/src/synergia/libFF/tests/test_zeroparticle_propagate.cc
@@ -92,6 +92,14 @@ void propagate_test_elem(std::string const& elem_def, double tolerance)
     for(int i=0; i<4; ++i) {
         CHECK (std::abs(parts(0, i)) < tolerance);
     }
+
+    // Make sure elapsed c dt matches element length
+    Reference_particle const& refpart = b.get_design_reference_particle();
+    double cdtlength = refpart.get_state()[4]*refpart.get_beta();
+    double elem_length = pf.lattice.get_length();
+
+    CHECK( abs(1-cdtlength/elem_length) < 1.0e-7 );
+
 }
 
 TEST_CASE("sbend")


### PR DESCRIPTION
Saving cdt for propagation through the RF cavity was incorrectly removed in a previous PR. Restored it, and added a test in the element propagation.