### PR TITLE
pconstants::kg_to_GeV is now defined in terms of other constants so it

### DIFF
--- a/src/synergia/foundation/foundation_pywrap.cc
+++ b/src/synergia/foundation/foundation_pywrap.cc
@@ -328,6 +328,7 @@ PYBIND11_MODULE(foundation, m)
     pc.attr("positron_charge") = pconstants::positron_charge;
     pc.attr("muon_charge") = pconstants::muon_charge;
     pc.attr("antimuon_charge") = pconstants::antimuon_charge;
+    pc.attr("kg_to_GeV") = pconstants::kg_to_GeV;
 
     // Four_momentum
     py::class_<Four_momentum>(m, "Four_momentum")

--- a/src/synergia/foundation/physical_constants.h
+++ b/src/synergia/foundation/physical_constants.h
@@ -22,9 +22,6 @@ namespace pconstants {
     constexpr double mmu = 0.1056583715;       // Mass of muon [GeV/c^2]
     constexpr double muon_mass = 0.1056583715; // Mass of muon [GeV/c^2]
     constexpr double e = 1.602176565e-19;      // Charge of proton [C]
-    constexpr double kg_to_GeV =
-        5.6095886038044526e+26; // conversion of mass from SI units to GeV used
-                                // by synergia3
 #else
 #if PDG_VERSION == 2010
     //  K. Nakamura et al. (Particle Data Group), J. Phys. G 37, 075021 (2010)
@@ -118,6 +115,12 @@ namespace pconstants {
     constexpr int positron_charge = 1;    // Charge in units of e
     constexpr int muon_charge = -1;       // Charge in units of e
     constexpr int antimuon_charge = 1;    // Charge in units of e
+
+    // mass [kg] * c**2 [m^2/s^2] = E [J]
+    // E[j]/q[C} = E [eV]
+    // conversion of mass from SI units to GeV used
+    constexpr double kg_to_GeV = 1.0e-9 * c * c / e;
+
 }
 
 #endif /* PHYSICAL_CONSTANTS_H_ */

--- a/src/synergia/foundation/tests/CMakeLists.txt
+++ b/src/synergia/foundation/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ if(BUILD_PYTHON_BINDINGS)
   add_py_test(test_version.py)
   add_py_test(test_four_momentum.py)
   add_py_test(test_reference_particle.py)
+  add_py_test(test_kg_to_GeV.py)
 
 endif()
 

--- a/src/synergia/foundation/tests/test_kg_to_GeV.py
+++ b/src/synergia/foundation/tests/test_kg_to_GeV.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import synergia.foundation
+import pytest
+
+def test_kg_to_Gev():
+    kg_to_GeV_derived = 1.0e-9 * synergia.foundation.pconstants.c**2/synergia.foundation.pconstants.e
+    print('kg_to_GeV_derived: ', kg_to_GeV_derived)
+    print('pconstants.kg_to_GeV: ', synergia.foundation.pconstants.kg_to_GeV)
+    assert kg_to_GeV_derived == pytest.approx(synergia.foundation.pconstants.kg_to_GeV, rel=1.0e-15)
+
+if __name__ == "__main__":
+    test_kg_to_Gev()


### PR DESCRIPTION
is consistent.

Added python wrapping for the constant and test.  Resolves Issue#222