### PR TITLE
Egstern/wake function operations are not implemented

### DIFF
--- a/src/synergia/collective/collective_pywrap.cc
+++ b/src/synergia/collective/collective_pywrap.cc
@@ -54,11 +54,16 @@ PYBIND11_MODULE(collective, m)
                    "Communication group size (must be 1 on GPUs).");
 
   py::class_<Impedance_options>(m, "Impedance_options")
+    .def(py::init<std::string const&, std::string const&>(),
+         "Options for constructing the impedance operator.",
+         "wake_file"_a,
+         "wake_type"_a)
+
     .def(py::init<std::string const&, std::string const&, int>(),
          "Construct the impedance operator.",
          "wake_file"_a,
          "wake_type"_a,
-         "z_grid"_a)
+         "z_grid"_a=1000)
 
     .def_readwrite("z_grid",
                    &Impedance_options::z_grid,
@@ -82,7 +87,30 @@ PYBIND11_MODULE(collective, m)
 
     .def_readwrite("bunch_spacing",
                    &Impedance_options::bunch_spacing,
-                   "Bunch spacing (double, default to 1.0).");
+                   "Bunch spacing (double, default to 1.0).")
+                   
+     .def_readwrite("mwf_xlead",
+                    &Impedance_options::mwf_xlead,
+                    "factor to scale x leading wake")
+
+     .def_readwrite("mwf_xtrail",
+                    &Impedance_options::mwf_xtrail,
+                    "factor to scale x trailing wake")
+                    
+     .def_readwrite("mwf_ylead",
+                    &Impedance_options::mwf_ylead,
+                    "factor to scale y leading wake")
+                    
+     .def_readwrite("mwf_ytrail",
+                    &Impedance_options::mwf_ytrail,
+                    "factor to scale y trailing wake")
+                    
+     .def_readwrite("mwf_zwake",
+                    &Impedance_options::mwf_zwake,
+                    "factor to scale z (longitudinal) wake")
+                    
+                    ; // terminates Impedance_options class wrappings
+
 
   py::class_<Dummy_CO_options>(m, "Dummy_CO_options")
     .def(py::init<>(), "Construct a dummy collective operator.");

--- a/src/synergia/collective/impedance.cc
+++ b/src/synergia/collective/impedance.cc
@@ -554,7 +554,9 @@ Impedance::Impedance(Impedance_options const& opts)
     , h_zbinning()
     , wakes()
     , h_wakes()
-    , wake_field(opts.wake_file, opts.wake_type)
+    , wake_field(opts.wake_file, opts.wake_type,
+        opts.mwf_xlead, opts.mwf_xtrail, opts.mwf_ylead, opts.mwf_ytrail,
+        opts.mwf_zwake)
 {}
 
 void

--- a/src/synergia/collective/tests/CMakeLists.txt
+++ b/src/synergia/collective/tests/CMakeLists.txt
@@ -14,6 +14,10 @@ target_link_libraries(test_space_charge_3d_rectangular_mpi synergia_collective
                       synergia_serialization synergia_test_main)
 add_mpi_test(test_space_charge_3d_rectangular_mpi 1)
 
+if(BUILD_PYTHON_BINDINGS)
+  add_py_test(test_impedance_options.py)
+endif()
+
 if(${BUILD_FD_SPACE_CHARGE_SOLVER})
   add_executable(test_space_charge_3d_fd_mpi test_space_charge_3d_fd_mpi.cc)
   target_link_libraries(test_space_charge_3d_fd_mpi synergia_collective

--- a/src/synergia/collective/tests/test_impedance_options.py
+++ b/src/synergia/collective/tests/test_impedance_options.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+import sys, os
+import numpy as np
+import synergia
+import pytest
+
+def test_default_contructor():
+    io = synergia.collective.Impedance_options("foo.dat", "XLYLZ")
+
+def test_constructor_onearg():
+    io = synergia.collective.Impedance_options("foo.dat", "XLYLZ", 100)
+
+def test_IO_defaults():
+    io = synergia.collective.Impedance_options("foo.dat", "XLYLZ")
+
+    assert io.z_grid == 1000
+
+    assert not io.full_machine
+
+    assert io.nstored_turns == 15
+
+    assert io.num_buckets == 1
+
+    assert io.orbit_length == 1.0
+
+    assert io.bunch_spacing == 1.0
+
+    assert io.mwf_xlead == 1.0
+
+    assert io.mwf_xtrail == 1.0
+
+    assert io.mwf_ylead == 1.0
+
+    assert io.mwf_ytrail == 1.0
+
+    assert io.mwf_zwake == 1.0
+
+def test_IO_set_attributes():
+    io = synergia.collective.Impedance_options("foo.dat", "XLYLZ", 100)
+    assert io.z_grid == 100
+
+    io.num_buckets = 4
+    assert io.num_buckets == 4
+
+    io.mwf_xlead = 0.5
+    assert io.mwf_xlead == 0.5
+
+    io.mwf_xtrail = 0.0
+    assert io.mwf_xtrail == 0.0
+
+    io.mwf_ylead = 0.25
+    assert io.mwf_ylead == 0.25
+
+    io.mwf_ytrail = -0.75
+    assert io.mwf_ytrail == -0.75
+
+    io.mwf_zwake = 0.375
+    assert io.mwf_zwake == 0.375

--- a/src/synergia/collective/wake_field.cc
+++ b/src/synergia/collective/wake_field.cc
@@ -5,7 +5,12 @@
 #include <stdexcept>
 
 Wake_field::Wake_field(std::string const& wake_file,
-                       std::string const& wake_type)
+                      std::string const& wake_type,
+                      const double& mwf_xlead,
+                      const double& mwf_xtrail,
+                      const double& mwf_ylead,
+                      const double& mwf_ytrail,
+                      const double& mwf_zwake)
   : wake_file(wake_file), wake_type(wake_type)
 {
 
@@ -80,7 +85,7 @@ Wake_field::Wake_field(std::string const& wake_file,
                 z_coord_v.push_back(temp_wake[0]);
 
                 if (wake_type == "Z") {
-                  z_wake_v.push_back(temp_wake[1]);
+                  z_wake_v.push_back(temp_wake[1]*mwf_zwake);
                 }
                 /* else if(wake_type=="XL") {
                     xw_lead.push_back(temp_wake[1]);
@@ -95,8 +100,8 @@ Wake_field::Wake_field(std::string const& wake_file,
                     yw_trail.push_back(temp_wake[1]);
                 } */
                 else if (wake_type == "XLYL") {
-                  xw_lead_v.push_back(temp_wake[1]);
-                  yw_lead_v.push_back(temp_wake[1]);
+                  xw_lead_v.push_back(temp_wake[1]*mwf_xlead);
+                  yw_lead_v.push_back(temp_wake[1]*mwf_ylead);
                 } else {
                   throw std::runtime_error("invalid specification of the wake "
                                            "type for 2 columns wake file");
@@ -142,14 +147,14 @@ Wake_field::Wake_field(std::string const& wake_file,
                     yw_trail.push_back(temp_wake[2]);
                 } 			*/
                 if (wake_type == "XLYLZ") {
-                  xw_lead_v.push_back(temp_wake[1]);
-                  yw_lead_v.push_back(temp_wake[1]);
-                  z_wake_v.push_back(temp_wake[2]);
+                  xw_lead_v.push_back(temp_wake[1]*mwf_xlead);
+                  yw_lead_v.push_back(temp_wake[1]*mwf_ylead);
+                  z_wake_v.push_back(temp_wake[2]*mwf_zwake);
                 } else if (wake_type == "XLXTYLYT") {
-                  xw_lead_v.push_back(temp_wake[1]);
-                  xw_trail_v.push_back(temp_wake[2]);
-                  yw_lead_v.push_back(temp_wake[1]);
-                  yw_trail_v.push_back(temp_wake[2]);
+                  xw_lead_v.push_back(temp_wake[1]*mwf_xlead);
+                  xw_trail_v.push_back(temp_wake[2]*mwf_xtrail);
+                  yw_lead_v.push_back(temp_wake[1]*mwf_ylead);
+                  yw_trail_v.push_back(temp_wake[2]*mwf_ytrail);
                 } else if (wake_type == "XZ_Elliptical_coeff") {
                   double cxs = 0.42; // approximate values for the main injector
                   double cxw =
@@ -157,11 +162,11 @@ Wake_field::Wake_field(std::string const& wake_file,
                   double cys = 0.81; //           be changed!!!
                   double cyw = 0.40;
                   double cl = 0.985;
-                  xw_lead_v.push_back(cxs * temp_wake[1]);
-                  xw_trail_v.push_back(cxw * temp_wake[1]);
-                  yw_lead_v.push_back(cys * temp_wake[1]);
-                  yw_trail_v.push_back(cyw * temp_wake[1]);
-                  z_wake_v.push_back(cl * temp_wake[2]);
+                  xw_lead_v.push_back(cxs * temp_wake[1]*mwf_xlead);
+                  xw_trail_v.push_back(cxw * temp_wake[1]*mwf_xtrail);
+                  yw_lead_v.push_back(cys * temp_wake[1]*mwf_ylead);
+                  yw_trail_v.push_back(cyw * temp_wake[1]*mwf_ytrail);
+                  z_wake_v.push_back(cl * temp_wake[2]*mwf_zwake);
                 } else {
                   throw std::runtime_error("invalid specification of the wake "
                                            "type for 3 columns wake file");
@@ -176,23 +181,23 @@ Wake_field::Wake_field(std::string const& wake_file,
                 z_coord_v.push_back(temp_wake[0]);
 
                 if (wake_type == "XLXTYLYTZ") {
-                  xw_lead_v.push_back(temp_wake[1]);
-                  xw_trail_v.push_back(temp_wake[2]);
-                  yw_lead_v.push_back(temp_wake[1]);
-                  yw_trail_v.push_back(temp_wake[2]);
-                  z_wake_v.push_back(temp_wake[3]);
+                  xw_lead_v.push_back(temp_wake[1]*mwf_xlead);
+                  xw_trail_v.push_back(temp_wake[2]*mwf_xtrail);
+                  yw_lead_v.push_back(temp_wake[1]*mwf_ylead);
+                  yw_trail_v.push_back(temp_wake[2]*mwf_ytrail);
+                  z_wake_v.push_back(temp_wake[3]*mwf_zwake);
                 } else if (wake_type == "XLYLZ") {
-                  xw_lead_v.push_back(temp_wake[1]);
-                  yw_lead_v.push_back(temp_wake[2]);
-                  z_wake_v.push_back(temp_wake[3]);
+                  xw_lead_v.push_back(temp_wake[1]*mwf_xlead);
+                  yw_lead_v.push_back(temp_wake[2]*mwf_ylead);
+                  z_wake_v.push_back(temp_wake[3]*mwf_zwake);
                 } else if (wake_type ==
                            "XLXTYLYTZpp") { // this is for old wake files for
                                             // parallel planes geometry
-                  xw_lead_v.push_back(temp_wake[1]);
-                  xw_trail_v.push_back(-temp_wake[1]);
-                  yw_lead_v.push_back(temp_wake[2]);
-                  yw_trail_v.push_back(temp_wake[1]);
-                  z_wake_v.push_back(temp_wake[3]);
+                  xw_lead_v.push_back(temp_wake[1]*mwf_xlead);
+                  xw_trail_v.push_back(-temp_wake[1]*mwf_xtrail);
+                  yw_lead_v.push_back(temp_wake[2]*mwf_ylead);
+                  yw_trail_v.push_back(temp_wake[1]*mwf_ytrail);
+                  z_wake_v.push_back(temp_wake[3]*mwf_zwake);
                 } else {
                   throw std::runtime_error("invalid specification of the wake "
                                            "type for 4 columns wake file");
@@ -207,21 +212,21 @@ Wake_field::Wake_field(std::string const& wake_file,
                 z_coord_v.push_back(temp_wake[0]);
 
                 if (wake_type == "XLXTYLYT") {
-                  xw_lead_v.push_back(temp_wake[1]);
-                  xw_trail_v.push_back(temp_wake[2]);
-                  yw_lead_v.push_back(temp_wake[3]);
-                  yw_trail_v.push_back(temp_wake[4]);
+                  xw_lead_v.push_back(temp_wake[1]*mwf_xlead);
+                  xw_trail_v.push_back(temp_wake[2]*mwf_xtrail);
+                  yw_lead_v.push_back(temp_wake[3]*mwf_ylead);
+                  yw_trail_v.push_back(temp_wake[4]*mwf_ytrail);
                 } else if (wake_type == "XLXTYLYTZpp") {
-                  xw_lead_v.push_back(temp_wake[1]);
-                  xw_trail_v.push_back(-temp_wake[1]);
-                  yw_lead_v.push_back(temp_wake[2]);
-                  yw_trail_v.push_back(temp_wake[3]);
-                  z_wake_v.push_back(temp_wake[4]);
+                  xw_lead_v.push_back(temp_wake[1]*mwf_xlead);
+                  xw_trail_v.push_back(-temp_wake[1]*mwf_xtrail);
+                  yw_lead_v.push_back(temp_wake[2]*mwf_ylead);
+                  yw_trail_v.push_back(temp_wake[3]*mwf_ytrail);
+                  z_wake_v.push_back(temp_wake[4]*mwf_zwake);
                 } else if (wake_type == "TRANSVERSEpp") {
-                  xw_lead_v.push_back(temp_wake[1]);
-                  xw_trail_v.push_back(-temp_wake[1]);
-                  yw_lead_v.push_back(temp_wake[2]);
-                  yw_trail_v.push_back(temp_wake[3]);
+                  xw_lead_v.push_back(temp_wake[1]*mwf_xlead);
+                  xw_trail_v.push_back(-temp_wake[1]*mwf_xtrail);
+                  yw_lead_v.push_back(temp_wake[2]*mwf_ylead);
+                  yw_trail_v.push_back(temp_wake[3]*mwf_ytrail);
                   // z_wake.push_back();
                 } else {
                   throw std::runtime_error("invalid specification of the wake "
@@ -237,11 +242,11 @@ Wake_field::Wake_field(std::string const& wake_file,
                 z_coord_v.push_back(temp_wake[0]);
 
                 if (wake_type == "XLXTYLYTZ") {
-                  xw_lead_v.push_back(temp_wake[1]);
-                  xw_trail_v.push_back(temp_wake[2]);
-                  yw_lead_v.push_back(temp_wake[3]);
-                  yw_trail_v.push_back(temp_wake[4]);
-                  z_wake_v.push_back(temp_wake[5]);
+                  xw_lead_v.push_back(temp_wake[1]*mwf_xlead);
+                  xw_trail_v.push_back(temp_wake[2]*mwf_xtrail);
+                  yw_lead_v.push_back(temp_wake[3]*mwf_ylead);
+                  yw_trail_v.push_back(temp_wake[4]*mwf_ytrail);
+                  z_wake_v.push_back(temp_wake[5]*mwf_zwake);
                 } else {
                   throw std::runtime_error("invalid specification of the wake "
                                            "type for 6 columns wake file");

--- a/src/synergia/collective/wake_field.h
+++ b/src/synergia/collective/wake_field.h
@@ -22,7 +22,7 @@ struct Wake_field {
   // number of terms
   int size_wake;
 
-  // z_coord, z_wake, xw_lead, xw_trail, yw_lead, yw_trail
+   // z_coord, z_wake, xw_lead, xw_trail, yw_lead, yw_trail
   // all in a single buffer.
   //
   // total size = size_wake * 6. Fortran ordering.
@@ -62,7 +62,12 @@ struct Wake_field {
     karray1d_hst h_yw_trail;
 #endif
 
-  Wake_field(std::string const& wake_file, std::string const& wake_type);
+  Wake_field(std::string const& wake_file, std::string const& wake_type,
+    const double& mwf_xlead,
+    const double& mwf_xtrail,
+    const double& mwf_ylead,
+    const double& mwf_ytrail,
+    const double& mwf_zwake);
 
   void multiply_xw_lead(double mltp);
   void multiply_xw_trail(double mltp);

--- a/src/synergia/simulation/implemented_collective_options.h
+++ b/src/synergia/simulation/implemented_collective_options.h
@@ -214,6 +214,11 @@ struct Impedance_options {
     double orbit_length;
     double bunch_spacing;
     std::array<int, 3> wn;
+    double mwf_xlead;
+    double mwf_xtrail;
+    double mwf_ylead;
+    double mwf_ytrail;
+    double mwf_zwake;
 
     Impedance_options(std::string const& wake_file = "",
                       std::string const& wake_type = "",
@@ -226,6 +231,11 @@ struct Impedance_options {
         , num_buckets(1)
         , orbit_length(1)
         , bunch_spacing(1)
+        , mwf_xlead(1.0)
+        , mwf_xtrail(1.0)
+        , mwf_ylead(1.0)
+        , mwf_ytrail(1.0)
+        , mwf_zwake(1.0)
     {}
 
     template <class Archive>
@@ -240,6 +250,11 @@ struct Impedance_options {
         ar(num_buckets);
         ar(orbit_length);
         ar(bunch_spacing);
+        ar(mwf_xlead);
+        ar(mwf_xtrail);
+        ar(mwf_ylead);
+        ar(mwf_ytrail);
+        ar(mwf_zwake);
     }
 };
 


### PR DESCRIPTION
The old methods to multiply wakes by factor would not be helpful because the wake functions are wrapped inside the impedance operation object which is buried somewhere inaccessible. Instead, I added multiplication factors for each wake function into the Impedance_options object which is used to create the Wake_function by reading the file. The factors can be applied at that time.