### PR TITLE
pybind11 to 2.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,7 +346,7 @@ if(BUILD_PYTHON_BINDINGS)
     FetchContent_Declare(
       pybind11
       GIT_REPOSITORY https://github.com/pybind/pybind11
-      GIT_TAG v2.11.1)
+      GIT_TAG v2.12.0)
     FetchContent_MakeAvailable(pybind11)
   endif()
 else(BUILD_PYTHON_BINDINGS)


### PR DESCRIPTION
https://pybind11.readthedocs.io/en/stable/changelog.html#version-2-12-0-march-27-2025