### PR TITLE
Add `MemoryLocation {Host, Device}` member in `bunch_particles` to keep track of where particles are

### DIFF
--- a/src/synergia/bunch/bunch.h
+++ b/src/synergia/bunch/bunch.h
@@ -658,7 +658,7 @@ class bunch_t {
 
     // checkpoint partiles
     void
-    save_checkpoint_particles(Hdf5_file& file, int idx) const
+    save_checkpoint_particles(Hdf5_file& file, int idx)
     {
         get_bunch_particles(PG::regular).save_checkpoint_particles(file, idx);
         get_bunch_particles(PG::spectator).save_checkpoint_particles(file, idx);

--- a/src/synergia/bunch/bunch_particles.cc
+++ b/src/synergia/bunch/bunch_particles.cc
@@ -718,8 +718,7 @@ bunch_particles_t<double>::print_particle(size_t idx, Logger& logger) const
 
 template <>
 void
-bunch_particles_t<double>::save_checkpoint_particles(Hdf5_file& file,
-                                                     int idx) const
+bunch_particles_t<double>::save_checkpoint_particles(Hdf5_file& file, int idx)
 {
     checkout_particles();
 

--- a/src/synergia/bunch/core_diagnostics.cc
+++ b/src/synergia/bunch/core_diagnostics.cc
@@ -206,8 +206,13 @@ Core_diagnostics::calculate_mean(Bunch const& bunch)
 
     karray1d mean("mean", 6);
 
-    auto particles = bunch.get_local_particles();
-    auto masks = bunch.get_local_particle_masks();
+    auto bparts = bunch.get_bunch_particles();
+    if (bparts.get_memory_location() == MemoryLocation::Host) {
+        std::runtime_error("Bunch particles are active on Host memory space!");
+    }
+
+    auto particles = bparts.parts;
+    auto masks = bparts.masks;
     const int npart = bunch.size();
 
     particle_reducer<mean_tag> pr(particles, masks);
@@ -231,8 +236,12 @@ Core_diagnostics::calculate_z_mean(Bunch const& bunch)
 
     double mean = 0;
 
-    auto particles = bunch.get_local_particles();
-    auto masks = bunch.get_local_particle_masks();
+    auto bparts = bunch.get_bunch_particles();
+    if (bparts.get_memory_location() == MemoryLocation::Host) {
+        std::runtime_error("Bunch particles are active on Host memory space!");
+    }
+    auto particles = bparts.parts;
+    auto masks = bparts.masks;
     const int npart = bunch.size();
 
     particle_reducer<z_mean_tag> pr(particles, masks);
@@ -255,8 +264,12 @@ Core_diagnostics::calculate_abs_mean(Bunch const& bunch)
 
     karray1d abs_mean("abs_mean", 6);
 
-    auto particles = bunch.get_local_particles();
-    auto masks = bunch.get_local_particle_masks();
+    auto bparts = bunch.get_bunch_particles();
+    if (bparts.get_memory_location() == MemoryLocation::Host) {
+        std::runtime_error("Bunch particles are active on Host memory space!");
+    }
+    auto particles = bparts.parts;
+    auto masks = bparts.masks;
     const int npart = bunch.size();
 
     particle_reducer<abs_mean_tag> pr(particles, masks);
@@ -284,8 +297,12 @@ Core_diagnostics::calculate_std(Bunch const& bunch, karray1d const& mean)
 
     karray1d std("std", 6);
 
-    auto particles = bunch.get_local_particles();
-    auto masks = bunch.get_local_particle_masks();
+    auto bparts = bunch.get_bunch_particles();
+    if (bparts.get_memory_location() == MemoryLocation::Host) {
+        std::runtime_error("Bunch particles are active on Host memory space!");
+    }
+    auto particles = bparts.parts;
+    auto masks = bparts.masks;
     const int npart = bunch.size();
 
     particle_reducer<std_tag> pr(particles, masks, mean);
@@ -308,8 +325,12 @@ Core_diagnostics::calculate_sum2(Bunch const& bunch, karray1d const& mean)
 
     karray2d_row sum2("sum2", 6, 6);
 
-    auto particles = bunch.get_local_particles();
-    auto masks = bunch.get_local_particle_masks();
+    auto bparts = bunch.get_bunch_particles();
+    if (bparts.get_memory_location() == MemoryLocation::Host) {
+        std::runtime_error("Bunch particles are active on Host memory space!");
+    }
+    auto particles = bparts.parts;
+    auto masks = bparts.masks;
     auto npart = bunch.size();
 
     particle_reducer<mom2_tag> pr(particles, masks, mean);
@@ -350,8 +371,12 @@ Core_diagnostics::calculate_min(Bunch const& bunch)
     min(1) = 1e100;
     min(2) = 1e100;
 
-    auto particles = bunch.get_local_particles();
-    auto masks = bunch.get_local_particle_masks();
+    auto bparts = bunch.get_bunch_particles();
+    if (bparts.get_memory_location() == MemoryLocation::Host) {
+        std::runtime_error("Bunch particles are active on Host memory space!");
+    }
+    auto particles = bparts.parts;
+    auto masks = bparts.masks;
     const int npart = bunch.size();
 
     particle_reducer<min_tag> pr(particles, masks);
@@ -375,8 +400,12 @@ Core_diagnostics::calculate_max(Bunch const& bunch)
     max(1) = -1e100;
     max(2) = -1e100;
 
-    auto particles = bunch.get_local_particles();
-    auto masks = bunch.get_local_particle_masks();
+    auto bparts = bunch.get_bunch_particles();
+    if (bparts.get_memory_location() == MemoryLocation::Host) {
+        std::runtime_error("Bunch particles are active on Host memory space!");
+    }
+    auto particles = bparts.parts;
+    auto masks = bparts.masks;
     const int npart = bunch.size();
 
     particle_reducer<max_tag> pr(particles, masks);
@@ -395,8 +424,12 @@ Core_diagnostics::calculate_spatial_mean_stddev(Bunch const& bunch)
     using core_diagnostics_impl::particle_reducer;
     using core_diagnostics_impl::spatial_mean_stddev_tag;
 
-    auto particles = bunch.get_local_particles();
-    auto masks = bunch.get_local_particle_masks();
+    auto bparts = bunch.get_bunch_particles();
+    if (bparts.get_memory_location() == MemoryLocation::Host) {
+        std::runtime_error("Bunch particles are active on Host memory space!");
+    }
+    auto particles = bparts.parts;
+    auto masks = bparts.masks;
     const int npart = bunch.size();
 
     const auto total_bunch_particles = bunch.get_total_num();

--- a/src/synergia/bunch/core_diagnostics.cc
+++ b/src/synergia/bunch/core_diagnostics.cc
@@ -1,9 +1,5 @@
 #include <cmath>
-#include <functional>
 #include <stdexcept>
-
-#include "synergia/foundation/physical_constants.h"
-#include "synergia/utils/logger.h"
 
 #include "core_diagnostics.h"
 

--- a/src/synergia/bunch/tests/test_bunch.cc
+++ b/src/synergia/bunch/tests/test_bunch.cc
@@ -41,17 +41,16 @@ TEST_CASE("Bunch", "[Bunch]")
     CHECK(p2(0, 6) == 123);
     CHECK(p2(1, 6) == 124);
     CHECK(p2(4, 6) == 127);
-    
-    CHECK(bunch.get_real_num() == Approx(1e13) );
-    bunch.set_real_num(1.2e13);
-    CHECK(bunch.get_real_num() == Approx(1.2e13) );
 
+    CHECK(bunch.get_real_num() == Approx(1e13));
+    bunch.set_real_num(1.2e13);
+    CHECK(bunch.get_real_num() == Approx(1.2e13));
 }
 
 #if defined SYNERGIA_HAVE_OPENPMD
 
 void
-check_particle_values(BunchParticles const& bp1, BunchParticles const& bp2)
+check_particle_values(BunchParticles& bp1, BunchParticles& bp2)
 {
     bp1.checkout_particles();
     bp2.checkout_particles();

--- a/src/synergia/bunch/tests/test_bunch_particles.cc
+++ b/src/synergia/bunch/tests/test_bunch_particles.cc
@@ -25,7 +25,7 @@ init_particle_values(BunchParticles& bp)
 }
 
 void
-check_particle_values(BunchParticles const& bp)
+check_particle_values(BunchParticles& bp)
 {
     bp.checkout_particles();
 

--- a/src/synergia/simulation/bunch_simulator.cc
+++ b/src/synergia/simulation/bunch_simulator.cc
@@ -502,7 +502,7 @@ namespace {
 }
 
 void
-Bunch_simulator::save_checkpoint_particles(std::string const& fname) const
+Bunch_simulator::save_checkpoint_particles(std::string const& fname)
 {
     Hdf5_file file(fname, Hdf5_file::Flag::truncate, *comm);
     auto bunches = get_bunch_ptrs(trains);

--- a/src/synergia/simulation/bunch_simulator.h
+++ b/src/synergia/simulation/bunch_simulator.h
@@ -430,7 +430,7 @@ class Bunch_simulator {
                                const_karray1d limits);
 
     // serialization helper
-    void save_checkpoint_particles(std::string const& fname) const;
+    void save_checkpoint_particles(std::string const& fname);
     void load_checkpoint_particles(std::string const& fname);
 
     std::string

--- a/src/synergia/simulation/propagator.cc
+++ b/src/synergia/simulation/propagator.cc
@@ -49,6 +49,7 @@ Propagator::do_step(Bunch_simulator& simulator,
     // ensure that particles are on the device in case any of the
     // following might have transferred them onto the host
     // custom diagnostics routines, turn_end_action, etc
+    Kokkos::Profiling::pushRegion("memory-location check before step-apply");
     for (auto& train : simulator.get_trains()) {
         for (auto& bunch : train.get_bunches()) {
             auto bparts = bunch.get_bunch_particles();
@@ -58,6 +59,7 @@ Propagator::do_step(Bunch_simulator& simulator,
             }
         }
     }
+    Kokkos::Profiling::popRegion();
 
     // propagate through the step
     step.apply(simulator, logger);

--- a/src/synergia/simulation/propagator.cc
+++ b/src/synergia/simulation/propagator.cc
@@ -46,6 +46,19 @@ Propagator::do_step(Bunch_simulator& simulator,
     // lattice elements has been updated
     lattice.update();
 
+    // ensure that particles are on the device in case any of the
+    // following might have transferred them onto the host
+    // custom diagnostics routines, turn_end_action, etc
+    for (auto& train : simulator.get_trains()) {
+        for (auto& bunch : train.get_bunches()) {
+            auto bparts = bunch.get_bunch_particles();
+            if (bparts.get_memory_location() == MemoryLocation::Host) {
+                std::runtime_error(
+                    "Bunch particles are active on Host memory space!");
+            }
+        }
+    }
+
     // propagate through the step
     step.apply(simulator, logger);
 

--- a/src/synergia/simulation/step.cc
+++ b/src/synergia/simulation/step.cc
@@ -4,27 +4,30 @@
 #include "synergia/foundation/physical_constants.h"
 
 namespace {
-  void
-  apply_longitudinal_boundary(Bunch& bunch)
-  {
-    // Bunch longitudinal boundary condition
-    auto lb = bunch.get_longitudinal_boundary();
+    void
+    apply_longitudinal_boundary(Bunch& bunch)
+    {
+        // Bunch longitudinal boundary condition
+        auto lb = bunch.get_longitudinal_boundary();
 
-    switch (lb.first) {
-      case LongitudinalBoundary::periodic:
-        apply_longitudinal_periodicity(bunch, lb.second);
-        break;
+        switch (lb.first) {
+            case LongitudinalBoundary::periodic:
+                apply_longitudinal_periodicity(bunch, lb.second);
+                break;
 
-      case LongitudinalBoundary::aperture: apply_zcut(bunch, lb.second); break;
+            case LongitudinalBoundary::aperture:
+                apply_zcut(bunch, lb.second);
+                break;
 
-      case LongitudinalBoundary::bucket_barrier:
-        apply_longitudinal_bucket_barrier(bunch, lb.second);
-        break;
+            case LongitudinalBoundary::bucket_barrier:
+                apply_longitudinal_bucket_barrier(bunch, lb.second);
+                break;
 
-      case LongitudinalBoundary::open:
-      default: break;
+            case LongitudinalBoundary::open:
+            default:
+                break;
+        }
     }
-  }
 }
 
 Step::Step(double length) : operators(), step_betas(), length(length) {}
@@ -32,43 +35,45 @@ Step::Step(double length) : operators(), step_betas(), length(length) {}
 void
 Step::create_operations(Lattice const& lattice)
 {
-  for (auto& op : operators) { op->create_operations(lattice); }
+    for (auto& op : operators) {
+        op->create_operations(lattice);
+    }
 }
 
 void
 Step::apply(Bunch_simulator& simulator, Logger& logger) const
 {
-  if (simulator[0].get_bunch_array_size() == 0) {
-    throw std::runtime_error(
-      "Step::apply() unable to proceed. no bunch in the simulator");
-  }
+    if (simulator[0].get_bunch_array_size() == 0) {
+        throw std::runtime_error(
+            "Step::apply() unable to proceed. no bunch in the simulator");
+    }
 
-  // time [s] in accelerator frame
-  double ref_beta = simulator[0][0].get_reference_particle().get_beta();
-  double time = length / (ref_beta * pconstants::c);
+    // time [s] in accelerator frame
+    double ref_beta = simulator[0][0].get_reference_particle().get_beta();
+    double time = length / (ref_beta * pconstants::c);
 
-  for (auto const& op : operators) {
-    double t0 = MPI_Wtime();
+    for (auto const& op : operators) {
+        double t0 = MPI_Wtime();
 
-    logger(LoggerV::INFO_OPR) << "\n  Operator start:\n";
+        logger(LoggerV::INFO_OPR) << "\n  Operator start:\n";
 
-    // operator apply
-    op->apply(simulator, time, logger);
+        // operator apply
+        op->apply(simulator, time, logger);
 
-    double t1 = MPI_Wtime();
+        double t1 = MPI_Wtime();
 
-    logger(LoggerV::INFO_OPR)
-      << "  Operator finish: operator: name = " << op->get_name()
-      << ", type = " << op->get_type() << ", time = " << std::fixed
-      << std::setprecision(3) << t1 - t0 << "s"
-      << "\n";
+        logger(LoggerV::INFO_OPR)
+            << "  Operator finish: operator: name = " << op->get_name()
+            << ", type = " << op->get_type() << ", time = " << std::fixed
+            << std::setprecision(3) << t1 - t0 << "s"
+            << "\n";
 
-    // per operator diagnostics action
-    simulator.diag_action_operator(*op);
+        // per operator diagnostics action
+        simulator.diag_action_operator(*op);
 
-    // longitudinal conditions
-    for (auto& train : simulator.get_trains())
-      for (auto& bunch : train.get_bunches())
-        apply_longitudinal_boundary(bunch);
-  }
+        // longitudinal conditions
+        for (auto& train : simulator.get_trains())
+            for (auto& bunch : train.get_bunches())
+                apply_longitudinal_boundary(bunch);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/fnalacceleratormodeling/synergia2/issues/248 with a broader solution that introduces a new enum member `MemoryLocation { Host, Device }` in the `bunch_particles` class to keep track of where the particles reside. This can also be used to track down issues later on, if for instance particle data lives on the host but some function was called with the assumption that data lives on the device.  

An additional change that occurs due to the above is that any function that moves particles between device/host memories can no longer be `const`. 