### PR TITLE
ci-macos: print arch

### DIFF
--- a/.github/workflows/macos-clang.yml
+++ b/.github/workflows/macos-clang.yml
@@ -66,6 +66,7 @@ jobs:
         source ${{github.workspace}}/synergia-env/bin/activate
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+         -DGSV=DOUBLE \
          -DCMAKE_PREFIX_PATH=$(brew --prefix libomp) \
          -DPython_EXECUTABLE=${{github.workspace}}/synergia-env/bin/python${{env.PYTHON_VERSION}} \
          -DENABLE_KOKKOS_BACKEND=OpenMP -DBUILD_PYTHON_BINDINGS=on -DBUILD_EXAMPLES=off -GNinja

--- a/.github/workflows/macos-clang.yml
+++ b/.github/workflows/macos-clang.yml
@@ -62,6 +62,7 @@ jobs:
 
     - name: CMake
       run: |
+        uname -a
         source ${{github.workspace}}/synergia-env/bin/activate
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
          -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \

--- a/.github/workflows/macos-clang.yml
+++ b/.github/workflows/macos-clang.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
     - name: Cancel Previous runs

--- a/.github/workflows/macos-gcc.yml
+++ b/.github/workflows/macos-gcc.yml
@@ -52,7 +52,7 @@ jobs:
         uname -a
         source ${{github.workspace}}/synergia-env/bin/activate
         cmake -B ${{github.workspace}}/build \
-        -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 \
+        -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_KOKKOS_BACKEND=OpenMP \
         -DGSV=DOUBLE \
         -DPython_EXECUTABLE=${{github.workspace}}/synergia-env/bin/python${{env.PYTHON_VERSION}} \

--- a/.github/workflows/macos-gcc.yml
+++ b/.github/workflows/macos-gcc.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
     - name: Cancel Previous runs

--- a/.github/workflows/macos-gcc.yml
+++ b/.github/workflows/macos-gcc.yml
@@ -49,6 +49,7 @@ jobs:
 
     - name: CMake
       run: |
+        uname -a
         source ${{github.workspace}}/synergia-env/bin/activate
         cmake -B ${{github.workspace}}/build \
         -DCMAKE_OSX_ARCHITECTURES="x86_64" \

--- a/.github/workflows/macos-gcc.yml
+++ b/.github/workflows/macos-gcc.yml
@@ -52,9 +52,9 @@ jobs:
         uname -a
         source ${{github.workspace}}/synergia-env/bin/activate
         cmake -B ${{github.workspace}}/build \
-        -DCMAKE_OSX_ARCHITECTURES="x86_64" \
         -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 \
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_KOKKOS_BACKEND=OpenMP \
+        -DGSV=DOUBLE \
         -DPython_EXECUTABLE=${{github.workspace}}/synergia-env/bin/python${{env.PYTHON_VERSION}} \
         -DBUILD_PYTHON_BINDINGS=on -DBUILD_EXAMPLES=off -GNinja
 


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/