### PR TITLE
Added <numeric> header in test_hdf5_write_mpi.cc. Builds fail on Perl…

### DIFF
--- a/src/synergia/utils/tests/test_hdf5_write_mpi.cc
+++ b/src/synergia/utils/tests/test_hdf5_write_mpi.cc
@@ -1,4 +1,4 @@
-
+#include <numeric>
 
 #include <catch2/catch_test_macros.hpp>
 


### PR DESCRIPTION
…mutter

without it.