### PR TITLE
Egstern/276 adjust particles reference coordinate test fails on permutter and wc v100 nodes

### DIFF
--- a/src/synergia/bunch/bunch.cc
+++ b/src/synergia/bunch/bunch.cc
@@ -168,6 +168,13 @@ Bunch::print_statistics(Logger& logger) const
                       << "\n";
 }
 
+template <>
+void
+Bunch::adjust_bunch_particles_reference_energy(double newE)
+{
+  FF_adjust_bunch_ref_coords::apply(newE, *this);
+}
+
 #if defined SYNERGIA_HAVE_OPENPMD
 template <>
 void

--- a/src/synergia/bunch/bunch.h
+++ b/src/synergia/bunch/bunch.h
@@ -490,10 +490,7 @@ class bunch_t {
     // adjust_bunch_particle_reference_energy
     // This method adjusts the particle coordinates to use
     void
-    adjust_bunch_particles_reference_energy(double newE)
-    {
-        FF_adjust_bunch_ref_coords::apply(newE, *this);
-    }
+    adjust_bunch_particles_reference_energy(double newE);
     
     // bucket index
     void

--- a/src/synergia/bunch/tests/CMakeLists.txt
+++ b/src/synergia/bunch/tests/CMakeLists.txt
@@ -6,6 +6,10 @@ add_executable(test_bunch test_bunch.cc ${test_main})
 target_link_libraries(test_bunch PRIVATE synergia_bunch ${testing_libs})
 add_mpi_test(test_bunch 1)
 
+add_executable(test_adjust_particles_ref_energy test_adjust_particles_ref_energy.cc ${test_main})
+target_link_libraries(test_adjust_particles_ref_energy PRIVATE synergia_bunch ${testing_libs})
+add_mpi_test(test_adjust_particles_ref_energy 1)
+
 add_executable(test_bunch_particles test_bunch_particles.cc ${test_main})
 target_link_libraries(test_bunch_particles PRIVATE synergia_bunch
                                                    ${testing_libs})

--- a/src/synergia/bunch/tests/test_adjust_particles_ref_energy.cc
+++ b/src/synergia/bunch/tests/test_adjust_particles_ref_energy.cc
@@ -13,7 +13,7 @@
 
 constexpr double mass = pconstants::mp;
 constexpr double KE0 = 0.8;
-constexpr double total_energy = mp + KE0;
+constexpr double total_energy = mass + KE0;
 constexpr int total_num = 16;
 constexpr double real_num = 2.0e12;
 constexpr auto x = Bunch::x;
@@ -46,9 +46,10 @@ TEST_CASE("Bunch", "[Bunch]")
         parts(i, Bunch::yp) = (localnum-i) * 1.0e-4;
     }
 
-    constexpr double dE = 0.050 // 50 MeV
+    constexpr double dE = 0.050; // 50 MeV
     double energy = ref.get_total_energy();
-    old_p = sqrt(energy*energy - mass*mass)
+    double old_p = sqrt(energy*energy - mass*mass);
+	
 
     // Add some energy to each particle by changing dp/p
 
@@ -72,9 +73,11 @@ TEST_CASE("Bunch", "[Bunch]")
     for (auto i=0; i<localnum; ++i) {
         std::cout << "new_parts(i, 5): " << new_parts(i, 5) << std::endl;
         // check that dp/p is now close to 0
-        CHECK(Catch::Matchers::WithinAbs(parts(i, Bunch::dpop), 1.0e-12));
+        CHECK_THAT(parts(i, Bunch::dpop), Catch::Matchers::WithinAbs(0.0, 1.0e-12));
         // transverse momenta
-        CHECK(Catch::Matchers::WithinRel(i * 1.0e-4 * old_p/new_p, 1.0e-12));
-        CHECK(Catch::Matchers::WithinRel((localnum-i)*1.0e-4 * old_p/new_p, 1.0e-12));
+		std::cout << "new_parts(" << i << "(, 1): " << new_parts(i, 1) << std::endl;
+        CHECK_THAT(parts(i, Bunch::xp), Catch::Matchers::WithinRel(i*1.0e-4*old_p/new_p,  1.0e-12));
+		std::cout << "new_parts(" << i << "(, 3): " << new_parts(i, 3) << std::endl;
+        CHECK_THAT(parts(i, Bunch::yp), Catch::Matchers::WithinRel((localnum-i)*1.0e-4*old_p/new_p,  1.0e-12));
     }
 }

--- a/src/synergia/bunch/tests/test_adjust_particles_ref_energy.cc
+++ b/src/synergia/bunch/tests/test_adjust_particles_ref_energy.cc
@@ -1,0 +1,80 @@
+
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_NumericTraits.hpp>
+#include <Kokkos_Random.hpp>
+
+#include "synergia/bunch/bunch.h"
+#include "synergia/bunch/bunch_particles.h"
+#include "synergia/foundation/physical_constants.h"
+
+constexpr double mass = pconstants::mp;
+constexpr double KE0 = 0.8;
+constexpr double total_energy = mp + KE0;
+constexpr int total_num = 16;
+constexpr double real_num = 2.0e12;
+constexpr auto x = Bunch::x;
+constexpr auto xp = Bunch::xp;
+constexpr auto y = Bunch::y;
+constexpr auto yp = Bunch::yp;
+constexpr auto cdt = Bunch::cdt;
+constexpr auto dpop = Bunch::dpop;
+constexpr auto id = Bunch::id;
+constexpr int num_parts = 16;
+
+TEST_CASE("Bunch", "[Bunch]")
+{
+    Four_momentum fm(mass, total_energy);
+    Reference_particle ref(pconstants::proton_charge, fm);
+    Bunch bunch(ref, num_parts, 1e13, Commxx());
+
+    bunch.checkout_particles();
+    auto parts = bunch.get_host_particles();
+
+    auto localnum = bunch.get_local_num();
+    for(auto i=0; i<localnum; ++i) {
+        for(auto j=0; j<6; ++j) {
+            parts(i, j) = 0.0;
+        }
+    }
+    // also check transverse momenta
+    for (auto i=0; i<localnum; ++i) {
+        parts(i, Bunch::xp) = i * 1.0e-4;
+        parts(i, Bunch::yp) = (localnum-i) * 1.0e-4;
+    }
+
+    constexpr double dE = 0.050 // 50 MeV
+    double energy = ref.get_total_energy();
+    old_p = sqrt(energy*energy - mass*mass)
+
+    // Add some energy to each particle by changing dp/p
+
+    // what is that in dp/p
+    double new_energy = energy + dE;
+    double new_p = sqrt(new_energy*new_energy - mass*mass);
+    double new_dpop = new_p/old_p - 1.0;
+
+    for (auto i=0; i<localnum; ++i) {
+        parts(i, Bunch::dpop) = new_dpop;
+    }
+
+    bunch.checkin_particles();
+
+    // adjust the reference energy
+    bunch.adjust_bunch_particles_reference_energy(new_energy);
+
+    bunch.checkout_particles();
+    auto new_parts = bunch.get_host_particles();
+
+    for (auto i=0; i<localnum; ++i) {
+        std::cout << "new_parts(i, 5): " << new_parts(i, 5) << std::endl;
+        // check that dp/p is now close to 0
+        CHECK(Catch::Matchers::WithinAbs(parts(i, Bunch::dpop), 1.0e-12));
+        // transverse momenta
+        CHECK(Catch::Matchers::WithinRel(i * 1.0e-4 * old_p/new_p, 1.0e-12));
+        CHECK(Catch::Matchers::WithinRel((localnum-i)*1.0e-4 * old_p/new_p, 1.0e-12));
+    }
+}

--- a/src/synergia/lattice/lattice_pywrap.cc
+++ b/src/synergia/lattice/lattice_pywrap.cc
@@ -245,6 +245,12 @@ PYBIND11_MODULE(lattice, m)
 
     // Lattice_element_slice
     py::class_<Lattice_element_slice>(m, "Lattice_element_slice")
+        .def( py::init<Lattice_element const&>(), 
+                "Construct a lattice element slice from an entire element",
+                "element"_a)
+        .def (py::init<Lattice_element const&, double, double>(),
+                "Construct a lattice element slice with left and right from an element",
+                "element"_a, "left"_a, "right"_a)
         .def( "is_whole", 
                 &Lattice_element_slice::is_whole, 
                 "Is a whole element" )

--- a/src/synergia/libFF/ff_adjust_bunch_ref_coords.h
+++ b/src/synergia/libFF/ff_adjust_bunch_ref_coords.h
@@ -38,7 +38,6 @@ namespace ref_energy_impl {
                 gsv_t p4(&p(i, 4));
                 gsv_t p5(&p(i, 5));
 
-#if 1
                 FF_algorithm::adjust_ref_unit(p1,
                                                  p3,
                                                  p4,
@@ -48,7 +47,6 @@ namespace ref_energy_impl {
                                                  cp.new_p,
                                                  cp.old_E,
                                                  cp.new_E);
-#endif
 
                 p1.store(&p(i, 1));
                 p3.store(&p(i, 3));

--- a/src/synergia/libFF/ff_adjust_bunch_ref_coords.h
+++ b/src/synergia/libFF/ff_adjust_bunch_ref_coords.h
@@ -38,7 +38,7 @@ namespace ref_energy_impl {
                 gsv_t p4(&p(i, 4));
                 gsv_t p5(&p(i, 5));
 
-#if 0
+#if 1
                 FF_algorithm::adjust_ref_unit(p1,
                                                  p3,
                                                  p4,
@@ -142,7 +142,7 @@ namespace FF_adjust_bunch_ref_coords {
             auto range = Kokkos::RangePolicy<exec>(0, bunch.size_in_gsv(pg));
 
             AdjustCoords<BunchT> adjuster{parts, masks, cp};
-            // Kokkos::parallel_for(range, adjuster);
+            Kokkos::parallel_for(range, adjuster);
         };
         apply(ParticleGroup::regular);
         apply(ParticleGroup::spectator);

--- a/src/synergia/libFF/ff_adjust_bunch_ref_coords.h
+++ b/src/synergia/libFF/ff_adjust_bunch_ref_coords.h
@@ -38,6 +38,7 @@ namespace ref_energy_impl {
                 gsv_t p4(&p(i, 4));
                 gsv_t p5(&p(i, 5));
 
+#if 0
                 FF_algorithm::adjust_ref_unit(p1,
                                                  p3,
                                                  p4,
@@ -47,6 +48,7 @@ namespace ref_energy_impl {
                                                  cp.new_p,
                                                  cp.old_E,
                                                  cp.new_E);
+#endif
 
                 p1.store(&p(i, 1));
                 p3.store(&p(i, 3));
@@ -140,7 +142,7 @@ namespace FF_adjust_bunch_ref_coords {
             auto range = Kokkos::RangePolicy<exec>(0, bunch.size_in_gsv(pg));
 
             AdjustCoords<BunchT> adjuster{parts, masks, cp};
-            Kokkos::parallel_for(range, adjuster);
+            // Kokkos::parallel_for(range, adjuster);
         };
         apply(ParticleGroup::regular);
         apply(ParticleGroup::spectator);


### PR DESCRIPTION
Putting the adjust_bunch_particles_ref_energy() method into the .cc file works on GPUs. It seems the linker allows the GPU to be initialized properly when you do it that way.