### PR TITLE
add avx2 only on x86-64!

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -14,8 +14,6 @@ system-requirements = {cuda = "12"}
 channels = ["nvidia", "conda-forge"]
 
 [tasks]
-# On x86_64 CPUs, GSV should be set to AVX for improved performance
-cmake = { cmd = "cmake -S . -B build_pixi -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(pwd)/.pixi/envs/default -DCMAKE_INSTALL_PREFIX=$(pwd)/install_pixi -DENABLE_KOKKOS_BACKEND=OpenMP -DUSE_EXTERNAL_KOKKOS=OFF -DUSE_OPENPMD_IO=ON -DUSE_EXTERNAL_OPENPMD=OFF -DBUILD_FD_SPACE_CHARGE_SOLVER=OFF -DGSV=DOUBLE -DSIMPLE_TIMER=OFF", description = "Run cmake to generate the build recipes"}
 build = { cmd = "cmake --build build_pixi", depends_on = ["cmake"], description = "build synergia3" }
 install = { cmd = "cmake --install build_pixi", depends_on = ["build"], description = "install synergia3" }
 test = { cmd = "ctest --output-on-failure --test-dir build_pixi", depends_on = ["install"],env = { SYNINSTALL = "$(pwd)/install_pixi", LD_LIBRARY_PATH = "$SYNINSTALL/lib:$SYNINSTALL:lib64:$LD_LIBRARY_PATH",PYTHON_VERSION = "$(python3 -c 'import sys; print(str(sys.version[:4]))')",PYTHONPATH="$SYNINSTALL/lib:$SYNINSTALL/lib/python$PYTHON_VERSION/site-packages:$SYNINSTALL/lib:$SYNINSTALL/lib64/python$PYTHON_VERSION/site-packages:$PYTHONPATH" } , description = "run test suite" }
@@ -24,6 +22,13 @@ clean = { cmd = "rm -rf build_pixi/ && rm -rf install_pixi/", description = "del
 
 synergia = { cmd = "bash" , env = { SYNINSTALL = "$(pwd)/install_pixi", LD_LIBRARY_PATH="$SYNINSTALL/lib:$SYNINSTALL/lib64:$LD_LIBRARY_PATH", PYTHON_VERSION = "$(python3 -c 'import sys; print(str(sys.version[:4]))')", PYTHONPATH="$SYNINSTALL/lib/python$PYTHON_VERSION/site-packages"}, description = "start shell in built synergia environment" }
 
+[target.linux-64.tasks]
+# On x86_64 CPUs, GSV should be set to AVX2 for improved performance
+cmake = { cmd = "cmake -S . -B build_pixi -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(pwd)/.pixi/envs/default -DCMAKE_INSTALL_PREFIX=$(pwd)/install_pixi -DENABLE_KOKKOS_BACKEND=OpenMP -DUSE_EXTERNAL_KOKKOS=OFF -DUSE_OPENPMD_IO=ON -DUSE_EXTERNAL_OPENPMD=OFF -DBUILD_FD_SPACE_CHARGE_SOLVER=OFF -DGSV=AVX2 -DSIMPLE_TIMER=OFF", description = "Run cmake to generate the build recipes"}
+
+[target.osx-arm64.tasks]
+# On arm64 CPUs, GSV should be set to DOUBLE.
+cmake = { cmd = "cmake -S . -B build_pixi -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(pwd)/.pixi/envs/default -DCMAKE_INSTALL_PREFIX=$(pwd)/install_pixi -DENABLE_KOKKOS_BACKEND=OpenMP -DUSE_EXTERNAL_KOKKOS=OFF -DUSE_OPENPMD_IO=ON -DUSE_EXTERNAL_OPENPMD=OFF -DBUILD_FD_SPACE_CHARGE_SOLVER=OFF -DGSV=DOUBLE -DSIMPLE_TIMER=OFF", description = "Run cmake to generate the build recipes"}
 
 [feature.cuda.tasks]
 cmake = { cmd = "cmake -S . -B build_pixi -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(pwd)/install_pixi -DENABLE_KOKKOS_BACKEND=CUDA -DUSE_EXTERNAL_KOKKOS=OFF -DUSE_OPENPMD_IO=ON -DUSE_EXTERNAL_OPENPMD=OFF -DGSV=DOUBLE", description = "Run cmake to generate the build recipes"}


### PR DESCRIPTION
`AVX2` came out ~11 years ago. We can safely set them as the baseline now.