### PR TITLE
rename cmake variables to prevent clashes with Eigen3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,7 +445,7 @@ set(SYNERGIA3_INCLUDE_INSTALL_DIR
 set(SYNERGIA3_LIB_INSTALL_DIR
     "${CMAKE_INSTALL_PREFIX}/lib/"
     CACHE PATH "library install directory")
-set(BIN_INSTALL_DIR
+set(SYNERGIA3_BIN_INSTALL_DIR
     "${CMAKE_INSTALL_PREFIX}/bin/"
     CACHE PATH "executable install directory")
 set(PYTHON_INSTALL_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,7 +439,7 @@ add_custom_target(
   COMMENT "Running ctest")
 add_dependencies(check test-exes)
 
-set(INCLUDE_INSTALL_DIR
+set(SYNERGIA3_INCLUDE_INSTALL_DIR
     "${CMAKE_INSTALL_PREFIX}/include/"
     CACHE PATH "include install directory")
 set(LIB_INSTALL_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,7 +442,7 @@ add_dependencies(check test-exes)
 set(SYNERGIA3_INCLUDE_INSTALL_DIR
     "${CMAKE_INSTALL_PREFIX}/include/"
     CACHE PATH "include install directory")
-set(LIB_INSTALL_DIR
+set(SYNERGIA3_LIB_INSTALL_DIR
     "${CMAKE_INSTALL_PREFIX}/lib/"
     CACHE PATH "library install directory")
 set(BIN_INSTALL_DIR
@@ -461,7 +461,7 @@ set(SYNERGIA_EXTRA_PYTHON_PATHS
 
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-set(CMAKE_INSTALL_RPATH "${LIB_INSTALL_DIR}")
+set(CMAKE_INSTALL_RPATH "${SYNERGIA3_LIB_INSTALL_DIR}")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # possibly move the following to using block/endblock when cmake min version

--- a/src/analysis_tools/CMakeLists.txt
+++ b/src/analysis_tools/CMakeLists.txt
@@ -39,4 +39,4 @@ install(
         tracks_to_text.py
         particles_to_madX_text.py
         decode_mad8_twiss.py
-  DESTINATION ${LIB_INSTALL_DIR}/synergia_tools)
+  DESTINATION ${SYNERGIA3_LIB_INSTALL_DIR}/synergia_tools)

--- a/src/analysis_tools/CMakeLists.txt
+++ b/src/analysis_tools/CMakeLists.txt
@@ -21,7 +21,7 @@ foreach(tool ${tools})
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/${tool}.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/${tool}" IMMEDIATE)
   install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/${tool}"
-          DESTINATION ${BIN_INSTALL_DIR})
+          DESTINATION ${SYNERGIA3_BIN_INSTALL_DIR})
 endforeach(tool tools)
 
 install(

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -13,13 +13,13 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/synergia.in"
 # synergia_command_line synergia_collective)
 
 install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/synergia"
-        DESTINATION ${BIN_INSTALL_DIR})
+        DESTINATION ${SYNERGIA3_BIN_INSTALL_DIR})
 # install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/synergia-resume" DESTINATION
-# ${BIN_INSTALL_DIR}) install(PROGRAMS
+# ${SYNERGIA3_BIN_INSTALL_DIR}) install(PROGRAMS
 # "${CMAKE_CURRENT_BINARY_DIR}/synergia-pyresume" DESTINATION
-# ${BIN_INSTALL_DIR}) install(PROGRAMS
+# ${SYNERGIA3_BIN_INSTALL_DIR}) install(PROGRAMS
 # "${CMAKE_CURRENT_BINARY_DIR}/synergia-archive-convert" DESTINATION
-# ${BIN_INSTALL_DIR})
+# ${SYNERGIA3_BIN_INSTALL_DIR})
 
 # install(FILES synergia_resume.py DESTINATION
 # ${PYTHON_INSTALL_DIR}/synergia_tools)

--- a/src/synergia/CMakeLists.txt
+++ b/src/synergia/CMakeLists.txt
@@ -28,6 +28,6 @@ if(BUILD_PYTHON_BINDINGS)
   copy_file(__init__.py synergia)
 endif()
 
-install(TARGETS synergia DESTINATION ${LIB_INSTALL_DIR})
+install(TARGETS synergia DESTINATION ${SYNERGIA3_LIB_INSTALL_DIR})
 install(FILES __init__.py "${CMAKE_CURRENT_BINARY_DIR}/version.py"
         DESTINATION ${PYTHON_INSTALL_DIR}/synergia)

--- a/src/synergia/bunch/CMakeLists.txt
+++ b/src/synergia/bunch/CMakeLists.txt
@@ -69,6 +69,6 @@ install(
         fixed_t_z_converter.h
         populate.h
         period.h
-  DESTINATION ${INCLUDE_INSTALL_DIR}/synergia/bunch)
+  DESTINATION ${SYNERGIA3_INCLUDE_INSTALL_DIR}/synergia/bunch)
 
 add_subdirectory(tests)

--- a/src/synergia/bunch/CMakeLists.txt
+++ b/src/synergia/bunch/CMakeLists.txt
@@ -49,13 +49,13 @@ if(BUILD_PYTHON_BINDINGS)
   copy_file(__init__.py bunch)
 
   install(FILES __init__.py DESTINATION ${PYTHON_INSTALL_DIR}/synergia/bunch)
-  install(TARGETS synergia_pydiag DESTINATION ${LIB_INSTALL_DIR})
+  install(TARGETS synergia_pydiag DESTINATION ${SYNERGIA3_LIB_INSTALL_DIR})
   install(TARGETS bunch DESTINATION ${PYTHON_INSTALL_DIR}/synergia/bunch)
 
 endif()
 
 install(TARGETS synergia_bunch synergia_bunch_hostonly
-        DESTINATION ${LIB_INSTALL_DIR})
+        DESTINATION ${SYNERGIA3_LIB_INSTALL_DIR})
 
 install(
   FILES bunch.h

--- a/src/synergia/collective/CMakeLists.txt
+++ b/src/synergia/collective/CMakeLists.txt
@@ -39,7 +39,7 @@ install(
     space_charge_rectangular.h
     impedance.h
     wake_field.h
-  DESTINATION ${INCLUDE_INSTALL_DIR}/synergia/collective)
+  DESTINATION ${SYNERGIA3_INCLUDE_INSTALL_DIR}/synergia/collective)
 
 if(BUILD_PYTHON_BINDINGS)
   install(FILES __init__.py

--- a/src/synergia/foundation/CMakeLists.txt
+++ b/src/synergia/foundation/CMakeLists.txt
@@ -18,7 +18,7 @@ if(BUILD_PYTHON_BINDINGS)
   copy_file(__init__.py foundation)
 endif()
 
-install(TARGETS synergia_foundation DESTINATION ${LIB_INSTALL_DIR})
+install(TARGETS synergia_foundation DESTINATION ${SYNERGIA3_LIB_INSTALL_DIR})
 install(FILES distribution.h four_momentum.h physical_constants.h
               reference_particle.h
         DESTINATION ${SYNERGIA3_INCLUDE_INSTALL_DIR}/synergia/foundation)

--- a/src/synergia/foundation/CMakeLists.txt
+++ b/src/synergia/foundation/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 install(TARGETS synergia_foundation DESTINATION ${LIB_INSTALL_DIR})
 install(FILES distribution.h four_momentum.h physical_constants.h
               reference_particle.h
-        DESTINATION ${INCLUDE_INSTALL_DIR}/synergia/foundation)
+        DESTINATION ${SYNERGIA3_INCLUDE_INSTALL_DIR}/synergia/foundation)
 
 if(BUILD_PYTHON_BINDINGS)
   install(FILES __init__.py

--- a/src/synergia/lattice/CMakeLists.txt
+++ b/src/synergia/lattice/CMakeLists.txt
@@ -39,7 +39,7 @@ install(
         mx_expr.h
         mx_parse.h
         mx_tree.h
-  DESTINATION ${INCLUDE_INSTALL_DIR}/synergia/lattice)
+  DESTINATION ${SYNERGIA3_INCLUDE_INSTALL_DIR}/synergia/lattice)
 
 if(BUILD_PYTHON_BINDINGS)
   install(FILES __init__.py mad8_parser.py mad8_reader.py simplify.py

--- a/src/synergia/lattice/CMakeLists.txt
+++ b/src/synergia/lattice/CMakeLists.txt
@@ -28,7 +28,7 @@ if(BUILD_PYTHON_BINDINGS)
 endif()
 
 install(TARGETS synergia_lattice synergia_lattice_hostonly
-        DESTINATION ${LIB_INSTALL_DIR})
+        DESTINATION ${SYNERGIA3_LIB_INSTALL_DIR})
 
 install(
   FILES lattice_element.h

--- a/src/synergia/simulation/CMakeLists.txt
+++ b/src/synergia/simulation/CMakeLists.txt
@@ -54,7 +54,7 @@ install(
         split_operator_stepper.h
         split_operator_stepper_elements.h
         populate_stationary.h
-  DESTINATION ${INCLUDE_INSTALL_DIR}/synergia/simulation)
+  DESTINATION ${SYNERGIA3_INCLUDE_INSTALL_DIR}/synergia/simulation)
 
 if(BUILD_PYTHON_BINDINGS)
   install(FILES __init__.py

--- a/src/synergia/simulation/CMakeLists.txt
+++ b/src/synergia/simulation/CMakeLists.txt
@@ -37,7 +37,7 @@ if(BUILD_PYTHON_BINDINGS)
 endif()
 
 install(TARGETS synergia_simulation_hostonly synergia_simulation
-                synergia_bunchsim DESTINATION ${LIB_INSTALL_DIR})
+                synergia_bunchsim DESTINATION ${SYNERGIA3_LIB_INSTALL_DIR})
 
 install(
   FILES bunch_simulator.h

--- a/src/synergia/utils/CMakeLists.txt
+++ b/src/synergia/utils/CMakeLists.txt
@@ -90,8 +90,8 @@ endif()
 
 install(TARGETS synergia_parallel_utils synergia_distributed_fft
                 synergia_serialization synergia_command_line lsexpr
-        DESTINATION ${LIB_INSTALL_DIR})
-install(TARGETS synergia_hdf5_utils DESTINATION ${LIB_INSTALL_DIR})
+        DESTINATION ${SYNERGIA3_LIB_INSTALL_DIR})
+install(TARGETS synergia_hdf5_utils DESTINATION ${SYNERGIA3_LIB_INSTALL_DIR})
 
 install(
   FILES command_line_arg.h

--- a/src/synergia/utils/CMakeLists.txt
+++ b/src/synergia/utils/CMakeLists.txt
@@ -118,7 +118,7 @@ install(
         lsexpr.h
         synergia_config.h
         utils.h
-  DESTINATION ${INCLUDE_INSTALL_DIR}/synergia/utils)
+  DESTINATION ${SYNERGIA3_INCLUDE_INSTALL_DIR}/synergia/utils)
 if(BUILD_PYTHON_BINDINGS)
   install(FILES __init__.py DESTINATION ${PYTHON_INSTALL_DIR}/synergia/utils)
   install(TARGETS parallel_utils pylsexpr utils

--- a/synergia-script-templates/CMakeLists.txt
+++ b/synergia-script-templates/CMakeLists.txt
@@ -25,4 +25,4 @@ install(
         intrepid_resumemulti_footer
         intrepid_resumemulti_header
         resume_intrepid
-  DESTINATION ${LIB_INSTALL_DIR}/synergia-script-templates)
+  DESTINATION ${SYNERGIA3_LIB_INSTALL_DIR}/synergia-script-templates)


### PR DESCRIPTION
Error on perlmutter with new spack environment is:
```
-- using double for gsvector
-- Configuring Eigen3 for use in host routines.
CMake Error at src/synergia/utils/eigen/CMakeLists.txt:165 (file):
  file RELATIVE_PATH must be passed a full path to the directory:


-- 
```

Per cmake docs https://cmake.org/cmake/help/latest/command/set.html :
```
If the cache entry does not exist prior to the call or the FORCE option is given then the cache entry will be set to the given value.
```

Since we already set `INCLUDE_INSTALL_DIR`, `Eigen3` attempting to set it without `FORCE` results in a cmake failure. Renaming all relevant variables to prevent other clashes.