### PR TITLE
Start of the project to add simulated synchronization of the bunch

### DIFF
--- a/src/synergia/bunch/bunch.cc
+++ b/src/synergia/bunch/bunch.cc
@@ -175,6 +175,14 @@ Bunch::adjust_bunch_particles_reference_energy(double newE)
   FF_adjust_bunch_ref_coords::apply(newE, *this);
 }
 
+template <>
+void
+Bunch::offset_bunch_particles_cdt(double offset)
+{
+  FF_offset_cdt::apply(offset, *this);
+}
+
+
 #if defined SYNERGIA_HAVE_OPENPMD
 template <>
 void

--- a/src/synergia/bunch/bunch.h
+++ b/src/synergia/bunch/bunch.h
@@ -18,6 +18,7 @@
 #include "synergia/utils/logger.h"
 
 #include "synergia/libFF/ff_adjust_bunch_ref_coords.h"
+#include "synergia/libFF/ff_offset_bunch_cdt.h"
 
 #include <cereal/types/array.hpp>
 #include <cereal/types/map.hpp>
@@ -489,8 +490,14 @@ class bunch_t {
 
     // adjust_bunch_particle_reference_energy
     // This method adjusts the particle coordinates to use
+    // a different reference energy
     void
     adjust_bunch_particles_reference_energy(double newE);
+
+    // offset_bunch_particles_cdt
+    // apply offset to every particle cdt
+    void
+    offset_bunch_particles_cdt(double offset);
     
     // bucket index
     void

--- a/src/synergia/bunch/bunch_pywrap.cc
+++ b/src/synergia/bunch/bunch_pywrap.cc
@@ -210,6 +210,11 @@ PYBIND11_MODULE(bunch, m)
             "Set the reference energy of the bunch and adjust the normalization of the particles to match",
             "newE"_a)
 
+        .def("offset_bunch_particles_cdt",
+            &Bunch::offset_bunch_particles_cdt,
+            "Add offset to the cdt of all bunch particles",
+            "offset"_a)
+
         .def(
             "add_diagnostics",
             [](Bunch& self, std::shared_ptr<Diagnostics> const& diag) {

--- a/src/synergia/bunch/core_diagnostics.h
+++ b/src/synergia/bunch/core_diagnostics.h
@@ -29,7 +29,7 @@ struct Core_diagnostics {
         karray2d_row const& view);
 
     // calculate the median bunch cdt for each MPI rank and take the median of that
-    static calculate_median_cdt(Bunch const& bunch);
+    static double calculate_median_cdt(Bunch const& bunch);
 
 };
 

--- a/src/synergia/bunch/core_diagnostics.h
+++ b/src/synergia/bunch/core_diagnostics.h
@@ -27,6 +27,10 @@ struct Core_diagnostics {
     static std::vector<double> kokkos_view_to_stl_vector(karray1d const& view);
     static std::vector<double> kokkos_view_to_stl_vector(
         karray2d_row const& view);
+
+    // calculate the median bunch cdt for each MPI rank and take the median of that
+    static calculate_median_cdt(Bunch const& bunch);
+
 };
 
 #endif /* CORE_DIAGNOSTICS_H_ */

--- a/src/synergia/bunch/tests/CMakeLists.txt
+++ b/src/synergia/bunch/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(test_adjust_particles_ref_energy test_adjust_particles_ref_energy
 target_link_libraries(test_adjust_particles_ref_energy PRIVATE synergia_bunch ${testing_libs})
 add_mpi_test(test_adjust_particles_ref_energy 1)
 
+add_executable(test_offset_bunch_cdt test_offset_bunch_cdt.cc ${test_main})
+target_link_libraries(test_offset_bunch_cdt PRIVATE synergia_bunch ${testing_libs})
+add_mpi_test(test_offset_bunch_cdt 1)
+
 add_executable(test_bunch_particles test_bunch_particles.cc ${test_main})
 target_link_libraries(test_bunch_particles PRIVATE synergia_bunch
                                                    ${testing_libs})
@@ -19,4 +23,5 @@ if(BUILD_PYTHON_BINDINGS)
   add_py_test(test_bunch.py)
   add_py_test(test_bunch_reference_particles.py)
   add_py_test(test_adjust_particles_ref_energy.py)
+  add_py_test(test_offset_bunch_cdt.py)
   endif()

--- a/src/synergia/bunch/tests/test_offset_bunch_cdt.cc
+++ b/src/synergia/bunch/tests/test_offset_bunch_cdt.cc
@@ -1,0 +1,58 @@
+
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_NumericTraits.hpp>
+#include <Kokkos_Random.hpp>
+
+#include "synergia/bunch/bunch.h"
+#include "synergia/bunch/bunch_particles.h"
+#include "synergia/foundation/physical_constants.h"
+
+constexpr double mass = pconstants::mp;
+constexpr double KE0 = 0.8;
+constexpr double total_energy = mass + KE0;
+constexpr int total_num = 16;
+constexpr double real_num = 2.0e12;
+constexpr auto x = Bunch::x;
+constexpr auto xp = Bunch::xp;
+constexpr auto y = Bunch::y;
+constexpr auto yp = Bunch::yp;
+constexpr auto cdt = Bunch::cdt;
+constexpr auto dpop = Bunch::dpop;
+constexpr auto id = Bunch::id;
+constexpr int num_parts = 16;
+
+TEST_CASE("Bunch", "[Bunch]")
+{
+    Four_momentum fm(mass, total_energy);
+    Reference_particle ref(pconstants::proton_charge, fm);
+    Bunch bunch(ref, num_parts, 1e13, Commxx());
+
+    bunch.checkout_particles();
+    auto parts = bunch.get_host_particles();
+
+    auto localnum = bunch.get_local_num();
+    for(auto i=0; i<localnum; ++i) {
+        for(auto j=0; j<6; ++j) {
+            parts(i, j) = 0.0;
+        }
+        parts(i, Bunch::cdt) = i * 0.05;
+        std::cout << "before offset parts(i, 4): " << parts(i, 4) << std::endl;
+    }
+
+    bunch.checkin_particles();
+
+    // Offset the bunch cdt
+    bunch.offset_bunch_particles_cdt(-0.02);
+    
+    auto new_parts = bunch.get_host_particles();
+
+    for (auto i=0; i<localnum; ++i) {
+        std::cout << "after offset new_parts(i, 4): " << new_parts(i, 4) << std::endl;
+        // check that cdt has been offset
+        CHECK_THAT(parts(i, Bunch::cdt), Catch::Matchers::WithinAbs(i*0.05-0.02, 1.0e-12));
+    }
+}

--- a/src/synergia/bunch/tests/test_offset_bunch_cdt.py
+++ b/src/synergia/bunch/tests/test_offset_bunch_cdt.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import sys, os
+import numpy as np
+import synergia
+import pytest
+
+macroparticles=16
+realparticles=4.0e10
+
+KE0 = 0.8 # starting kinetic energy
+mp = synergia.foundation.pconstants.mp
+
+# prop_fixture is a Bunch
+@pytest.fixture
+def bunch_fixture():
+    ref_part = synergia.foundation.Reference_particle(1, mp, mp+KE0)
+    sim = synergia.simulation.Bunch_simulator.create_single_bunch_simulator(ref_part, macroparticles, realparticles)
+    bunch = sim.get_bunch()
+    bunch.checkout_particles()
+    lp = bunch.get_particles_numpy()
+    lp[:, 0:6] = 0.0
+    np = lp.shape[0]
+    for i in range(np):
+        lp[i, 4] = i * 0.05
+    bunch.checkin_particles()
+    return bunch
+
+
+def test_offset_bunch_cdt(bunch_fixture):
+
+    bunch_fixture.checkout_particles()
+    lp = bunch_fixture.get_particles_numpy()
+    print('particles cdt before offset: ', lp[:, 4])
+
+    # offset the cdt
+    bunch_fixture.offset_bunch_particles_cdt(-0.02)
+
+    # check that cdt is set correctly
+    bunch_fixture.checkout_particles()
+    lp = bunch_fixture.get_particles_numpy()
+    print('particles cdt after offset: ', lp[:, 4])
+    for i in range(lp.shape[0]):
+        assert lp[i, 4] == pytest.approx(i*0.05-0.02, abs=1.0e-12)
+
+def main():
+    bf = bunch_fixture()
+    test_offset_bunch_cdt(bf)
+
+if __name__ == "__main__":
+    main()

--- a/src/synergia/libFF/ff_algorithm.h
+++ b/src/synergia/libFF/ff_algorithm.h
@@ -1095,6 +1095,14 @@ namespace FF_algorithm {
 
     }
         
+    // adjust particle coordinates to use new reference energy
+    template <typename T>
+    KOKKOS_INLINE_FUNCTION void
+    adjust_cdt_unit(T& p4, double offset)
+    {
+            p4 = p4 + T(offset);
+    }
+        
     KOKKOS_INLINE_FUNCTION
     double
     factorial(int n)

--- a/src/synergia/libFF/ff_offset_bunch_cdt.h
+++ b/src/synergia/libFF/ff_offset_bunch_cdt.h
@@ -1,0 +1,109 @@
+#ifndef FF_OFFSET_CDT_H
+#define FF_OFFSET_CDT_H
+
+#include "synergia/foundation/physical_constants.h"
+#include "synergia/libFF/ff_algorithm.h"
+#include "synergia/libFF/ff_patterned_propagator.h"
+#include "synergia/utils/simple_timer.h"
+
+namespace offset_cdt_impl {
+    struct CoordParams {
+        double offset; // offset for cdt
+    };
+
+    template <class BunchT>
+    struct OffsetCoords {
+        using gsv_t = typename BunchT::gsv_t;
+
+        typename BunchT::bp_t::parts_t p;
+        typename BunchT::bp_t::const_masks_t m;
+        const CoordParams cp;
+
+        KOKKOS_INLINE_FUNCTION
+        void
+        operator()(const int idx) const
+        {
+            int i = idx * gsv_t::size();
+            int mask = 0;
+            for (int x = i; x < i + gsv_t::size(); ++x)
+                mask |= m(x);
+
+            if (mask) {
+                gsv_t p4(&p(i, 4));
+
+                FF_algorithm::adjust_cdt_unit(p4, cp.offset);
+
+                p4.store(&p(i, 4));
+            }
+        }
+    };
+
+    template <class BunchT>
+    struct PropOffset {
+        using gsv_t = typename BunchT::gsv_t;
+
+        typename BunchT::bp_t::parts_t p;
+        typename BunchT::bp_t::const_masks_t m;
+        const CoordParams cp;
+
+        KOKKOS_INLINE_FUNCTION
+        void
+        operator()(const int idx) const
+        {
+            int i = idx * gsv_t::size();
+            int mask = 0;
+            for (int x = i; x < i + gsv_t::size(); ++x)
+                mask |= m(x);
+
+            if (mask) {
+                gsv_t p4(&p(i, 4));
+
+                FF_algorithm::adjust_cdt_unit(p4, cp.offset);
+
+                p4.store(&p(i, 4));
+            }
+        }
+    };
+
+}
+
+namespace FF_offset_cdt {
+    template <class BunchT>
+    void
+    apply(double offset, BunchT& bunch)
+    {
+        using namespace offset_cdt_impl;
+
+        scoped_simple_timer timer("libFF_offset_cdt");
+
+        CoordParams cp;
+
+	cp.offset = offset;
+        // actually we don't care about the slice at all. Maybe
+        // we can eliminate the slice argument
+ 
+        Reference_particle& ref_l = bunch.get_design_reference_particle();
+        Reference_particle& ref_b = bunch.get_reference_particle();
+
+        // This operation does not affect any reference particle coordinates
+
+        // bunch particles
+        auto apply = [&](ParticleGroup pg) {
+            if (!bunch.get_local_num(pg)) return;
+
+            auto parts = bunch.get_local_particles(pg);
+            auto masks = bunch.get_local_particle_masks(pg);
+
+            using exec = typename BunchT::exec_space;
+            auto range = Kokkos::RangePolicy<exec>(0, bunch.size_in_gsv(pg));
+
+            PropOffset<BunchT> adjuster{parts, masks, cp};
+            Kokkos::parallel_for(range, adjuster);
+        };
+        apply(ParticleGroup::regular);
+        apply(ParticleGroup::spectator);
+
+    }
+}
+
+#endif // FF_OFFSET_CDT_H


### PR DESCRIPTION
longitudinal position with the RF cavities. This commit just adds the declaration for a routine to get the median bunch cdt to get the PR started.

In the real machine, there is a feedback system so that the RF phase is adjusted to match the bunch median longitudinal position. In Synergia, the timing is implicitly determined with respect to the RF cavities. If the RF cavity phase is locked to the bunch cdt centroid, then bunch must be adjusted so that the condition holds.

This PR adds routines to calculate (as best as possible) the bunch cdt centroid and a routine to center the bunch so that the centroid is 0. For MPI purposes, the median will be approximated by calculating the median for each MPI rank and taking the median of all that. This will be done on the CPU.
